### PR TITLE
[FEATURE] Support `n` parameter to generate multiple solutions

### DIFF
--- a/Classes/Cache/SolutionsCache.php
+++ b/Classes/Cache/SolutionsCache.php
@@ -132,6 +132,7 @@ final class SolutionsCache
                 $this->configuration->getModel(),
                 $this->configuration->getTemperature(),
                 $this->configuration->getMaxTokens(),
+                $this->configuration->getNumberOfCompletions(),
                 $problem->getPrompt(),
             ]),
         );

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -46,6 +46,7 @@ final class Configuration
     private const DEFAULT_MODEL = 'text-davinci-003';
     private const DEFAULT_TOKENS = 300;
     private const DEFAULT_TEMPERATURE = 0.5;
+    private const DEFAULT_NUMBER_OF_COMPLETIONS = 1;
     private const DEFAULT_CACHE_LIFETIME = 60 * 60 * 24; // 1 day
     private const DEFAULT_PROVIDER = ProblemSolving\Solution\Provider\OpenAISolutionProvider::class;
     private const DEFAULT_PROMPT = ProblemSolving\Solution\Prompt\DefaultPrompt::class;
@@ -97,6 +98,17 @@ final class Configuration
         }
 
         return (float)$temperature;
+    }
+
+    public function getNumberOfCompletions(): int
+    {
+        $numberOfCompletions = $this->provider->get('attributes/numberOfCompletions', self::DEFAULT_NUMBER_OF_COMPLETIONS);
+
+        if (!is_numeric($numberOfCompletions) || $numberOfCompletions < 1) {
+            $numberOfCompletions = self::DEFAULT_NUMBER_OF_COMPLETIONS;
+        }
+
+        return (int)$numberOfCompletions;
     }
 
     public function getCacheLifetime(): int

--- a/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
@@ -50,6 +50,7 @@ final class OpenAISolutionProvider implements SolutionProvider
                 'prompt' => $problem->getPrompt(),
                 'max_tokens' => $this->configuration->getMaxTokens(),
                 'temperature' => $this->configuration->getTemperature(),
+                'n' => $this->configuration->getNumberOfCompletions(),
             ]);
         } catch (\Exception) {
             throw Exception\UnableToSolveException::create($problem);

--- a/README.md
+++ b/README.md
@@ -59,16 +59,17 @@ the key must be configured in the extension configuration.
 
 The following extension configuration is available:
 
-| Configuration            | Description                                                                                                        | Default value                                                              |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
-| `provider`               | FQCN of the solution provider                                                                                      | [`EliasHaeussler\Typo3Solver\Solution\Provider\OpenAISolutionProvider`][3] |
-| `prompt`                 | FQCN of the prompt generator                                                                                       | [`EliasHaeussler\Typo3Solver\Prompt\DefaultPrompt`][4]                     |
-| `ignoredCodes`           | Comma-separated list of exception codes to ignore                                                                  | –                                                                          |
-| `api.key`                | [API key](#api-key) for OpenAI requests                                                                            | –                                                                          |
-| `attributes.model`       | [OpenAI model][13] to use (see [List available models](#list-available-models) to show a list of available models) | `text-davinci-003`                                                         |
-| `attributes.maxTokens`   | [Maximum number of tokens][14] to use per request                                                                  | `300`                                                                      |
-| `attributes.temperature` | [Temperature][15] to use for completion requests (must be a value between `0` and `1`)                             | `0.5`                                                                      |
-| `cache.lifetime`         | Lifetime in seconds of the solutions cache (use `0` to disable caching)                                            | `86400` (1 day)                                                            |
+| Configuration                    | Description                                                                                                        | Default value                                                              |
+|----------------------------------|--------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+| `provider`                       | FQCN of the solution provider                                                                                      | [`EliasHaeussler\Typo3Solver\Solution\Provider\OpenAISolutionProvider`][3] |
+| `prompt`                         | FQCN of the prompt generator                                                                                       | [`EliasHaeussler\Typo3Solver\Prompt\DefaultPrompt`][4]                     |
+| `ignoredCodes`                   | Comma-separated list of exception codes to ignore                                                                  | –                                                                          |
+| `api.key`                        | [API key](#api-key) for OpenAI requests                                                                            | –                                                                          |
+| `attributes.model`               | [OpenAI model][13] to use (see [List available models](#list-available-models) to show a list of available models) | `text-davinci-003`                                                         |
+| `attributes.maxTokens`           | [Maximum number of tokens][14] to use per request                                                                  | `300`                                                                      |
+| `attributes.temperature`         | [Temperature][15] to use for completion requests (must be a value between `0` and `1`)                             | `0.5`                                                                      |
+| `attributes.numberOfCompletions` | [Number of completions][16] to generate for each prompt                                                            | `1`                                                                        |
+| `cache.lifetime`                 | Lifetime in seconds of the solutions cache (use `0` to disable caching)                                            | `86400` (1 day)                                                            |
 
 ## ⚡ Usage
 
@@ -169,3 +170,4 @@ This project is licensed under [GNU General Public License 2.0 (or later)](LICEN
 [13]: https://platform.openai.com/docs/models
 [14]: https://platform.openai.com/docs/api-reference/completions/create#completions/create-max_tokens
 [15]: https://platform.openai.com/docs/api-reference/completions/create#completions/create-temperature
+[16]: https://platform.openai.com/docs/api-reference/completions/create#completions/create-n

--- a/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/Tests/Unit/Configuration/ConfigurationTest.php
@@ -177,6 +177,38 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
     /**
      * @test
      */
+    public function getNumberOfCompletionsReturnsDefaultNumberOfCompletionsIfNoNumberOfCompletionsIsConfigured(): void
+    {
+        self::assertSame(1, $this->subject->getNumberOfCompletions());
+    }
+
+    /**
+     * @test
+     */
+    public function getNumberOfCompletionsReturnsDefaultNumberOfCompletionsIfConfiguredNumberOfCompletionsIsInvalid(): void
+    {
+        $this->configurationProvider->configuration = [
+            'attributes/numberOfCompletions' => 'foo',
+        ];
+
+        self::assertSame(1, $this->subject->getNumberOfCompletions());
+    }
+
+    /**
+     * @test
+     */
+    public function getNumberOfCompletionsReturnsConfiguredNumberOfCompletions(): void
+    {
+        $this->configurationProvider->configuration = [
+            'attributes/numberOfCompletions' => 5,
+        ];
+
+        self::assertSame(5, $this->subject->getNumberOfCompletions());
+    }
+
+    /**
+     * @test
+     */
     public function getCacheLifetimeReturnsDefaultCacheLifetimeIfNoCacheLifetimeIsConfigured(): void
     {
         self::assertSame(60 * 60 * 24, $this->subject->getCacheLifetime());

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -19,5 +19,8 @@ attributes.maxTokens = 300
 # cat=attributes//30; type=string; label=Temperature to use for completion requests:Must be a float between 0 and 1
 attributes.temperature = 0.5
 
+# cat=attributes//40; type=int+; label=Number of provided completions:Must be an integer greater than 0
+attributes.numberOfCompletions = 1
+
 # cat=cache//10; type=int+; label=Lifetime of the solutions cache:Use "0" to disable caching
 cache.lifetime = 86400


### PR DESCRIPTION
The [`n`](https://platform.openai.com/docs/api-reference/completions/create#completions/create-n) parameter can be used to generate multiple completions for a single prompt. This PR adds support for this parameter via extension configuration `attributes/numberOfCompletions`.