### PR TITLE
[BUGFIX] Avoid completing code snippet provided in default prompt

### DIFF
--- a/Resources/Private/Templates/Prompt/Default.html
+++ b/Resources/Private/Templates/Prompt/Default.html
@@ -10,3 +10,5 @@ Exception: {exception.message -> f:format.raw()}
 Snippet including line numbers:
 {snippet -> f:format.raw()}
 </f:if>
+
+Possible fix:


### PR DESCRIPTION
The AI should not complete the code snippet provided in the default prompt. It should rather use the snippet to provide a meaningful solution.