### PR TITLE
[TASK] Ensure ignored codes are returned as list of integers

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -24,11 +24,11 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Configuration;
 
 use EliasHaeussler\Typo3Solver\ProblemSolving;
-
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core;
 
 use function array_filter;
 use function array_map;
+use function array_values;
 use function class_exists;
 use function is_a;
 use function is_numeric;
@@ -151,7 +151,7 @@ final class Configuration
     }
 
     /**
-     * @return array<int>
+     * @return list<int>
      */
     public function getIgnoredCodes(): array
     {
@@ -161,11 +161,13 @@ final class Configuration
             return [];
         }
 
-        return array_map(
-            'intval',
-            array_filter(
-                GeneralUtility::trimExplode(',', $ignoredCodes, true),
-                'is_numeric',
+        return array_values(
+            array_map(
+                'intval',
+                array_filter(
+                    Core\Utility\GeneralUtility::trimExplode(',', $ignoredCodes, true),
+                    'is_numeric',
+                ),
             ),
         );
     }

--- a/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/Tests/Unit/Configuration/ConfigurationTest.php
@@ -323,7 +323,7 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
     /**
      * @test
      */
-    public function getIgnoredCodesReturnsEmptyArrayIfCodesToIgnoreAreConfigured(): void
+    public function getIgnoredCodesReturnsEmptyArrayIfCodesToIgnoreAreNotConfigured(): void
     {
         self::assertSame([], $this->subject->getIgnoredCodes());
     }
@@ -346,7 +346,7 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
     public function getIgnoredCodesReturnsConfiguredCodesToIgnore(): void
     {
         $this->configurationProvider->configuration = [
-            'ignoredCodes' => '1675962685, 123',
+            'ignoredCodes' => '1675962685, foo, 123',
         ];
 
         self::assertSame([1675962685, 123], $this->subject->getIgnoredCodes());


### PR DESCRIPTION
`Configuration::getIgnoredCodes()` should always return a list of integer values.

Can be merged once https://review.typo3.org/c/Packages/TYPO3.CMS/+/77788 is released.