### PR TITLE
[BUGFIX] Don't populate application path to backtrace generator

### DIFF
--- a/Classes/ProblemSolving/Solution/Prompt/DefaultPrompt.php
+++ b/Classes/ProblemSolving/Solution/Prompt/DefaultPrompt.php
@@ -61,7 +61,7 @@ final class DefaultPrompt implements Prompt
 
     private function createCodeSnippet(Throwable $exception): string
     {
-        $backtrace = Backtrace\Backtrace::createForThrowable($exception)->applicationPath(Core\Core\Environment::getProjectPath());
+        $backtrace = Backtrace\Backtrace::createForThrowable($exception);
         $frames = $backtrace->frames();
         $applicationFrame = $frames[$backtrace->firstApplicationFrameIndex()] ?? null;
         $snippet = '';


### PR DESCRIPTION
Passing the application path to the backtrace generator results in passing probably wrong code snippets in the default prompt. It must be ensured that the code snippet always reflects the code where an exception occurred.