### PR TITLE
[BUGFIX] Fail if OpenAI API key is missing or invalid

### DIFF
--- a/Classes/Exception/ApiKeyMissingException.php
+++ b/Classes/Exception/ApiKeyMissingException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "solver".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Solver\Exception;
+
+use Exception;
+
+/**
+ * ApiKeyMissingException
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ApiKeyMissingException extends Exception
+{
+    public static function create(): self
+    {
+        return new self(
+            'Please configure an OpenAI API key in the extension settings.',
+            1676618324,
+        );
+    }
+}

--- a/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
@@ -42,8 +42,16 @@ final class OpenAISolutionProvider implements SolutionProvider
         $this->client = $client ?? OpenAI::client($this->configuration->getApiKey() ?? '');
     }
 
+    /**
+     * @throws Exception\ApiKeyMissingException
+     * @throws Exception\UnableToSolveException
+     */
     public function getSolution(ProblemSolving\Problem\Problem $problem): ProblemSolving\Solution\Solution
     {
+        if ($this->configuration->getApiKey() === null) {
+            throw Exception\ApiKeyMissingException::create();
+        }
+
         try {
             $response = $this->client->completions()->create([
                 'model' => $this->configuration->getModel(),
@@ -61,7 +69,6 @@ final class OpenAISolutionProvider implements SolutionProvider
 
     public function canBeUsed(ProblemSolving\Problem\Problem $problem): bool
     {
-        return $this->configuration->getApiKey() !== null
-            && !in_array($problem->getException()->getCode(), $this->configuration->getIgnoredCodes(), true);
+        return !in_array($problem->getException()->getCode(), $this->configuration->getIgnoredCodes(), true);
     }
 }


### PR DESCRIPTION
This PR adds a new exception that is thrown if the OpenAI API key is missing or invalid. With #10 being implemented, this will lead to an exception message to be shown on the error page, improving the overall user experience of this extension.