### PR TITLE
[BUGFIX] Assure navigation between multiple solutions works as expected

### DIFF
--- a/Resources/Private/Templates/Solution/Web.html
+++ b/Resources/Private/Templates/Solution/Web.html
@@ -28,7 +28,7 @@
         </div>
     </div>
     <div class="solution-body">
-        {formattedChoices -> f:format.raw()}
+        <form>{formattedChoices -> f:format.raw()}</form>
     </div>
     <details class="solution-prompt">
         <summary>Show prompt</summary>


### PR DESCRIPTION
The navigation of multiple solutions is based on a CSS-only slider. Navigation arrows are input elements of type `radio`, the first one being checked as initial state. However, using the `checked` attribute on radio buttons only works reliably when they're wrapped in a `<form>` tag. See https://stackoverflow.com/a/41943819 for reference.