### PR TITLE
[BUGFIX] Avoid removing too much content from HTML-rendered solutions

### DIFF
--- a/Classes/Formatter/WebFormatter.php
+++ b/Classes/Formatter/WebFormatter.php
@@ -33,7 +33,6 @@ use function explode;
 use function file_exists;
 use function file_get_contents;
 use function is_numeric;
-use function nl2br;
 
 /**
  * WebFormatter.
@@ -117,7 +116,7 @@ final class WebFormatter implements Formatter
     private function formatText(string $text): string
     {
         return $this->renderer->render('Section/Text.html', [
-            'text' => nl2br($text),
+            'text' => $text,
         ]);
     }
 

--- a/Resources/Private/Templates/Section/Text.html
+++ b/Resources/Private/Templates/Section/Text.html
@@ -1,1 +1,1 @@
-<p>{text -> f:format.raw()}</p>
+<pre class="text-raw">{text}</pre>

--- a/Resources/Public/Css/solutions.css
+++ b/Resources/Public/Css/solutions.css
@@ -119,16 +119,18 @@
     display: block;
 }
 
-.solution-choice p:first-child {
+.solution-choice-container > *:first-child {
     margin-top: 0;
 }
 
-.solution-choice p:last-child {
+.solution-choice-container > *:last-child {
     margin-bottom: 0;
 }
 
-.solution-choice pre {
-    margin: 0;
+.solution-choice pre.text-raw {
+    white-space: normal;
+    font-family: inherit;
+    border: none;
 }
 
 .solution-prompt {


### PR DESCRIPTION
AI generated solutions may contain inline HTML tags that are part of the viewable completion text. By using `f:format.raw()` those tags were converted to actual HTML tags, thus being invisible to the user on the HTML-rendered error page.

We now use an unstyled `pre` tag for the solution view in order to decorated the output as good as possible, including all relevant information from the completion response.