### PR TITLE
[BUGFIX] Inject solution only once on error page

### DIFF
--- a/Classes/Error/AiSolverExceptionHandler.php
+++ b/Classes/Error/AiSolverExceptionHandler.php
@@ -27,11 +27,10 @@ use EliasHaeussler\Typo3Solver\Configuration;
 use EliasHaeussler\Typo3Solver\Exception;
 use EliasHaeussler\Typo3Solver\Formatter;
 use EliasHaeussler\Typo3Solver\ProblemSolving;
+use EliasHaeussler\Typo3Solver\Utility;
 use EliasHaeussler\Typo3Solver\View;
 use Throwable;
 use TYPO3\CMS\Core;
-
-use function str_replace;
 
 /**
  * AiSolverExceptionHandler.
@@ -85,7 +84,11 @@ final class AiSolverExceptionHandler extends Core\Error\DebugExceptionHandler
             return $content;
         }
 
-        return str_replace('<div class="trace">', $solution . '<div class="trace">', $content);
+        return Utility\StringUtility::replaceFirstOccurrence(
+            '<div class="trace">',
+            $solution . '<div class="trace">',
+            $content,
+        );
     }
 
     protected function getStylesheet(): string

--- a/Classes/Utility/StringUtility.php
+++ b/Classes/Utility/StringUtility.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "solver".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Solver\Utility;
+
+use function mb_strlen;
+use function strpos;
+use function substr_replace;
+
+/**
+ * StringUtility
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class StringUtility
+{
+    /**
+     * @see https://stackoverflow.com/a/1252710
+     */
+    public static function replaceFirstOccurrence(string $search, string $replace, string $subject): string
+    {
+        $position = strpos($subject, $search);
+
+        if ($position === false) {
+            return $subject;
+        }
+
+        return substr_replace($subject, $replace, $position, mb_strlen($search));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
 	],
 	"require": {
 		"php": "~8.1.0 || ~8.2.0",
+		"ext-mbstring": "*",
 		"openai-php/client": "^0.3.0",
 		"spatie/backtrace": "^1.2",
 		"symfony/console": "^5.4 || ^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f14f35b1db4b18845d87703d4efdc7a0",
+    "content-hash": "14c4b2b9a38b08e53cb4b76e0e0e0f13",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -9028,7 +9028,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0"
+        "php": "~8.1.0 || ~8.2.0",
+        "ext-mbstring": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"


### PR DESCRIPTION
When multiple traces are rendered on the error page (that is, exceptions have previous exceptions attached), the AI generated solution must not be rendered multiple times. Thus, a new helper method `StringUtility::replaceFirstOccurrence()` is introduced and used instead of a plain `str_replace`.