### PR TITLE
[TASK] Re-use rendering context in TemplateRenderer

### DIFF
--- a/Classes/Error/AiSolverExceptionHandler.php
+++ b/Classes/Error/AiSolverExceptionHandler.php
@@ -98,7 +98,7 @@ final class AiSolverExceptionHandler extends Core\Error\DebugExceptionHandler
 
     private function renderException(\Exception $exception): string
     {
-        return $this->renderer->render('Message/Exception.html', [
+        return $this->renderer->render('Message/Exception', [
             'exception' => $exception,
             'exceptionClass' => $exception::class,
         ]);

--- a/Classes/Formatter/CliFormatter.php
+++ b/Classes/Formatter/CliFormatter.php
@@ -47,7 +47,7 @@ final class CliFormatter implements Formatter
 
     public function format(ProblemSolving\Solution\Solution $solution): string
     {
-        $formattedSolution = $this->renderer->render('Solution/Cli.html', [
+        $formattedSolution = $this->renderer->render('Solution/Cli', [
             'solution' => $solution,
             'showPrompt' => $this->output?->isVerbose(),
         ]);

--- a/Classes/Formatter/WebFormatter.php
+++ b/Classes/Formatter/WebFormatter.php
@@ -76,7 +76,7 @@ final class WebFormatter implements Formatter
             $formattedChoices .= '<div class="solution-choice">' . $formattedChoice . '</div>';
         }
 
-        return $this->renderer->render('Solution/Web.html', [
+        return $this->renderer->render('Solution/Web', [
             'solution' => $solution,
             'numberOfChoices' => $numberOfChoices,
             'formattedChoices' => $formattedChoices,
@@ -97,14 +97,14 @@ final class WebFormatter implements Formatter
 
     private function renderSingleChoice(string $formattedChoice): string
     {
-        return $this->renderer->render('Choice/SingleChoice.html', [
+        return $this->renderer->render('Choice/SingleChoice', [
             'formattedChoice' => $formattedChoice,
         ]);
     }
 
     private function renderMultipleChoices(string $formattedChoice, int $index, int $numberOfChoices): string
     {
-        return $this->renderer->render('Choice/MultipleChoices.html', [
+        return $this->renderer->render('Choice/MultipleChoices', [
             'formattedChoice' => $formattedChoice,
             'numberOfChoices' => $numberOfChoices,
             'index' => $index,
@@ -115,7 +115,7 @@ final class WebFormatter implements Formatter
 
     private function formatText(string $text): string
     {
-        return $this->renderer->render('Section/Text.html', [
+        return $this->renderer->render('Section/Text', [
             'text' => $text,
         ]);
     }
@@ -125,7 +125,7 @@ final class WebFormatter implements Formatter
      */
     private function formatCodeBlock(array $lines): string
     {
-        return $this->renderer->render('Section/CodeBlock.html', [
+        return $this->renderer->render('Section/CodeBlock', [
             'lines' => $lines,
         ]);
     }

--- a/Classes/ProblemSolving/Solution/Prompt/DefaultPrompt.php
+++ b/Classes/ProblemSolving/Solution/Prompt/DefaultPrompt.php
@@ -49,7 +49,7 @@ final class DefaultPrompt implements Prompt
 
     public function generate(Throwable $exception): string
     {
-        $prompt = $this->renderer->render('Prompt/Default.html', [
+        $prompt = $this->renderer->render('Prompt/Default', [
             'exception' => $exception,
             'snippet' => $this->createCodeSnippet($exception),
             'mode' => Core\Core\Environment::isComposerMode() ? 'composer' : 'classic (symlink)',

--- a/Classes/View/TemplateRenderer.php
+++ b/Classes/View/TemplateRenderer.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3Solver\View;
 
-use Symfony\Component\Filesystem;
 use TYPO3Fluid\Fluid;
 
 use function dirname;
@@ -37,11 +36,11 @@ use function dirname;
  */
 final class TemplateRenderer
 {
-    private readonly string $templateRootPath;
+    private readonly Fluid\Core\Rendering\RenderingContextInterface $renderingContext;
 
     public function __construct()
     {
-        $this->templateRootPath = dirname(__DIR__, 2) . '/Resources/Private/Templates';
+        $this->renderingContext = $this->createRenderingContext();
     }
 
     /**
@@ -49,14 +48,21 @@ final class TemplateRenderer
      */
     public function render(string $templatePath, array $variables = []): string
     {
-        $renderingContext = new Fluid\Core\Rendering\RenderingContext();
-        $renderingContext->getTemplatePaths()->setTemplatePathAndFilename(
-            Filesystem\Path::join($this->templateRootPath, $templatePath),
-        );
-
-        $view = new Fluid\View\TemplateView($renderingContext);
+        $view = new Fluid\View\TemplateView($this->renderingContext);
         $view->assignMultiple($variables);
 
-        return $view->render();
+        return $view->render($templatePath);
+    }
+
+    private function createRenderingContext(): Fluid\Core\Rendering\RenderingContextInterface
+    {
+        $rootPath = dirname(__DIR__, 2) . '/Resources/Private';
+        $renderingContext = new Fluid\Core\Rendering\RenderingContext();
+
+        $templatePaths = $renderingContext->getTemplatePaths();
+        $templatePaths->setTemplateRootPaths([$rootPath . '/Templates']);
+        $templatePaths->setPartialRootPaths([$rootPath . '/Partials']);
+
+        return $renderingContext;
     }
 }


### PR DESCRIPTION
Since template paths are always the same, we can safely pre-create a re-usable rendering context in the `TemplateRenderer`. This also allows to omit the file extension for rendering.