### PR TITLE
[BUGFIX] Break spaces in rendered solution text

### DIFF
--- a/Resources/Public/Css/solutions.css
+++ b/Resources/Public/Css/solutions.css
@@ -128,7 +128,7 @@
 }
 
 .solution-choice pre.text-raw {
-    white-space: normal;
+    white-space: break-spaces;
     font-family: inherit;
     border: none;
 }


### PR DESCRIPTION
This is a follow-up to #14 where a wrong CSS value for `white-space` was set.