### PR TITLE
[BUGFIX] Remove unnecessary line in default prompt

### DIFF
--- a/Resources/Private/Templates/Prompt/Default.html
+++ b/Resources/Private/Templates/Prompt/Default.html
@@ -1,7 +1,6 @@
 You are a very good PHP developer and an expert in developing websites with TYPO3 CMS.
 Use the following context to find a possible fix for the exception message at the end.
 The exception occurred in a TYPO3 system with version {typo3Version} installed. It runs in {mode} mode.
-Keep in mind that there's not always an issue with the code snippet at the end. Please take the exception message into consideration as well.
 
 <f:if condition="{exception.file}">File: {exception.file}</f:if>
 Exception: {exception.message -> f:format.raw()}


### PR DESCRIPTION
This line was added because the solution mostly contained code that tried to fix the mentioned code snippet. However, this was already solved by appending the prompt with a line "Possible fix:".