### PR TITLE
[TASK] Run `composer normalize` for TER libraries as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,10 @@
 			"@fix:editorconfig",
 			"@fix:php"
 		],
-		"fix:composer": "@composer normalize",
+		"fix:composer": [
+			"@composer normalize",
+			"@composer normalize Resources/Private/Libs/Build/composer.json"
+		],
 		"fix:editorconfig": "@lint:editorconfig --fix",
 		"fix:php": "php-cs-fixer fix",
 		"lint": [


### PR DESCRIPTION
When running `composer normalize` with `composer lint:composer` or `composer fix:composer`, the `composer.json` for TER libraries is now checked as well.