### PR TITLE
[BUGFIX] Assure generic behavior of cached solution provider

### DIFF
--- a/Classes/ProblemSolving/Solution/Provider/CacheSolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/CacheSolutionProvider.php
@@ -25,11 +25,8 @@ namespace EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider;
 
 use EliasHaeussler\Typo3Solver\Cache;
 use EliasHaeussler\Typo3Solver\ProblemSolving;
-use OpenAI\Responses;
 use Throwable;
 use Traversable;
-
-use function array_values;
 
 /**
  * CacheSolutionProvider.
@@ -78,25 +75,14 @@ final class CacheSolutionProvider implements StreamedSolutionProvider
 
         // Create empty solution
         $solution = null;
-        $choices = [];
 
-        // Create streamed solutions
-        foreach ($this->provider->getStreamedSolution($problem) as $streamedSolution) {
-            foreach ($streamedSolution->getChoices() as $choice) {
-                $previousMessages = ($choices[$choice->index] ?? null)?->message->content;
-                $choiceArray = $choice->toArray();
-                $choiceArray['message']['content'] = $previousMessages . $choice->message->content;
-
-                $choices[$choice->index] = Responses\Chat\CreateResponseChoice::from($choiceArray);
-            }
-
-            yield $solution = new ProblemSolving\Solution\Solution(
-                array_values($choices),
-                $streamedSolution->getModel(),
-                $streamedSolution->getPrompt(),
-            );
+        // Yield streamed solutions
+        /* @phpstan-ignore-next-line */
+        foreach ($this->provider->getStreamedSolution($problem) as $solution) {
+            yield $solution;
         }
 
+        // Cache last streamed solution
         if ($solution !== null) {
             $this->cache->set($problem, $solution);
         }

--- a/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
@@ -131,7 +131,7 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         $this->provider->solutionStream = $solution;
 
         $expected1 = Tests\Unit\DataProvider\SolutionDataProvider::get(2);
-        $expected2 = Tests\Unit\DataProvider\SolutionDataProvider::get(2, 'message {index} ... message {index}');
+        $expected2 = Tests\Unit\DataProvider\SolutionDataProvider::get(2, ' ... message {index}');
 
         $actual = iterator_to_array($this->subject->getStreamedSolution($problem));
 

--- a/Tests/Unit/ProblemSolving/Solution/SolutionTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/SolutionTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Solution;
 
 use DateTimeImmutable;
 use EliasHaeussler\Typo3Solver as Src;
-use GuzzleHttp\Psr7;
 use OpenAI\Responses;
 use TYPO3\TestingFramework;
 
@@ -98,79 +97,6 @@ final class SolutionTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame('prompt', $actual->getPrompt());
         self::assertSame('model', $actual->getModel());
         self::assertEquals([$choice], $actual->getChoices());
-    }
-
-    /**
-     * @test
-     */
-    public function fromStreamReturnsSolution(): void
-    {
-        $streamedResponse1 = [
-            'id' => 'id',
-            'object' => 'object',
-            'created' => 123,
-            'model' => 'model',
-            'choices' => [
-                [
-                    'index' => 0,
-                    'delta' => [
-                        'role' => 'role',
-                        'content' => 'content',
-                    ],
-                    'finish_reason' => null,
-                ],
-            ],
-        ];
-        $streamedResponse2 = [
-            'id' => 'id 2',
-            'object' => 'object 2',
-            'created' => 1234,
-            'model' => 'model 2',
-            'choices' => [
-                [
-                    'index' => 0,
-                    'delta' => [
-                        'role' => 'role 2',
-                        'content' => 'content 2',
-                    ],
-                    'finish_reason' => null,
-                ],
-            ],
-        ];
-
-        $response = new Psr7\Response();
-        $response->getBody()->write('data: ' . json_encode($streamedResponse1) . PHP_EOL);
-        $response->getBody()->write('data: ' . json_encode($streamedResponse2) . PHP_EOL);
-        $response->getBody()->rewind();
-
-        $stream = new Responses\StreamResponse(Responses\Chat\CreateStreamedResponse::class, $response);
-
-        $choice1 = Responses\Chat\CreateResponseChoice::from([
-            'index' => 0,
-            'message' => [
-                'role' => 'role',
-                'content' => 'content',
-            ],
-            'finish_reason' => null,
-        ]);
-        $choice2 = Responses\Chat\CreateResponseChoice::from([
-            'index' => 0,
-            'message' => [
-                'role' => 'role 2',
-                'content' => 'content 2',
-            ],
-            'finish_reason' => null,
-        ]);
-
-        $actual = iterator_to_array(Src\ProblemSolving\Solution\Solution::fromStream($stream, 'prompt'));
-
-        self::assertCount(2, $actual);
-        self::assertSame('prompt', $actual[0]->getPrompt());
-        self::assertSame('model', $actual[0]->getModel());
-        self::assertEquals([$choice1], $actual[0]->getChoices());
-        self::assertSame('prompt', $actual[1]->getPrompt());
-        self::assertSame('model 2', $actual[1]->getModel());
-        self::assertEquals([$choice2], $actual[1]->getChoices());
     }
 
     /**

--- a/Tests/Unit/ProblemSolving/SolverTest.php
+++ b/Tests/Unit/ProblemSolving/SolverTest.php
@@ -40,7 +40,6 @@ use function json_encode;
 final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
 {
     private Tests\Unit\Fixtures\DummyStreamedSolutionProvider $provider;
-    private Src\Formatter\JsonFormatter $formatter;
     private Src\ProblemSolving\Solver $subject;
 
     protected function setUp(): void
@@ -48,8 +47,7 @@ final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
         parent::setUp();
 
         $this->provider = new Tests\Unit\Fixtures\DummyStreamedSolutionProvider();
-        $this->formatter = new Src\Formatter\JsonFormatter();
-        $this->subject = new Src\ProblemSolving\Solver($this->provider, $this->formatter);
+        $this->subject = new Src\ProblemSolving\Solver($this->provider, new Src\Formatter\JsonFormatter());
 
         (new Src\Cache\SolutionsCache())->flush();
     }
@@ -101,7 +99,7 @@ final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
         $actual = iterator_to_array($this->subject->solveStreamed(new Exception()));
 
         $expected1 = Tests\Unit\DataProvider\SolutionDataProvider::get();
-        $expected2 = Tests\Unit\DataProvider\SolutionDataProvider::get(message: 'message {index} ... message {index}');
+        $expected2 = Tests\Unit\DataProvider\SolutionDataProvider::get(message: ' ... message {index}');
 
         self::assertCount(2, $actual);
         self::assertJsonStringEqualsJsonString(json_encode($expected1, JSON_THROW_ON_ERROR), $actual[0]);


### PR DESCRIPTION
The cached solution provider must not behave in the way it matches for the default solution provider. Instead, concrete providers must be responsible for providing solution streams their way. That's why the whole logic of solution stream merging is now moved from the cached solution provider to the default OpenAI solution provider.