### PR TITLE
[BUGFIX] Configure Renovate to ignore specific Composer platform reqs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,9 @@
 	"extends": [
 		"local>eliashaeussler/renovate-config"
 	],
+	"composerIgnorePlatformReqs": [
+		"ext-intl"
+	],
 	"packageRules": [
 		{
 			"extends": [


### PR DESCRIPTION
TYPO3 CMS requires the `ext-intl` PHP package to be installed. However, as this is not relevant for Renovate, we can safely ignore this requirement for Renovate updates.