### PR TITLE
[TASK] Drop support for `phpunit/phpcov` 8.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"ergebnis/composer-normalize": "^2.29",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan-symfony": "^1.2",
-		"phpunit/phpcov": "^8.2 || ^9.0",
+		"phpunit/phpcov": "^9.0",
 		"saschaegerer/phpstan-typo3": "^1.8",
 		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
 		"symfony/dependency-injection": "^5.4 || ^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98ea9f6b1fb7507391ce1bec47093a57",
+    "content-hash": "d039196010ab1afab926a21b710fa400",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
After upgrading to PHPUnit 10, we can safely remove support for `phpunit/phpcov` 8.x now.