### PR TITLE
[BUGFIX] Avoid usage of deprecated command property `$defaultName`

### DIFF
--- a/Classes/Command/CacheFlushCommand.php
+++ b/Classes/Command/CacheFlushCommand.php
@@ -36,12 +36,10 @@ use function sprintf;
  */
 final class CacheFlushCommand extends Console\Command\Command
 {
-    protected static $defaultName = 'solver:cache:flush';
-
     public function __construct(
         private readonly Cache\SolutionsCache $cache,
     ) {
-        parent::__construct();
+        parent::__construct('solver:cache:flush');
     }
 
     protected function configure(): void

--- a/Classes/Command/ListModelsCommand.php
+++ b/Classes/Command/ListModelsCommand.php
@@ -38,13 +38,12 @@ use function sort;
  */
 final class ListModelsCommand extends Console\Command\Command
 {
-    protected static $defaultName = 'solver:list-models';
-
     private readonly OpenAI\Client $client;
 
     public function __construct()
     {
-        parent::__construct();
+        parent::__construct('solver:list-models');
+
         $this->client = OpenAI::client((new Configuration\Configuration())->getApiKey() ?? '');
     }
 

--- a/Classes/Command/SolveCommand.php
+++ b/Classes/Command/SolveCommand.php
@@ -39,8 +39,6 @@ use Throwable;
  */
 final class SolveCommand extends Console\Command\Command
 {
-    protected static $defaultName = 'solver:solve';
-
     private readonly ProblemSolving\Solution\Provider\SolutionProvider $solutionProvider;
     private readonly Formatter\CliFormatter $cliFormatter;
     private readonly Formatter\JsonFormatter $jsonFormatter;
@@ -51,7 +49,7 @@ final class SolveCommand extends Console\Command\Command
         private readonly Cache\SolutionsCache $solutionsCache,
         ProblemSolving\Solution\Provider\SolutionProvider $solutionProvider = null,
     ) {
-        parent::__construct();
+        parent::__construct('solver:solve');
 
         $this->solutionProvider = $solutionProvider ?? $this->configuration->getProvider();
         $this->cliFormatter = new Formatter\CliFormatter();


### PR DESCRIPTION
The `$defaultName` property is deprecated as of `symfony/console` 6.1. Therefore, we should avoid its usage and instead pass the command name as constructor argument.