### PR TITLE
[BUGFIX] Roll back to PHPUnit 9.x

### DIFF
--- a/Tests/Functional/Middleware/PingMiddlewareTest.php
+++ b/Tests/Functional/Middleware/PingMiddlewareTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Functional\Middleware;
 
 use EliasHaeussler\Typo3Solver\Tests;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -43,7 +42,9 @@ final class PingMiddlewareTest extends TestingFramework\Core\Functional\Function
 
     protected bool $initializeDatabase = false;
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function middlewareIsSkippedOnUnsupportedRequest(): void
     {
         $request = self::createRequest('/tx_solver/ping')->withoutHeader('Accept');
@@ -52,7 +53,9 @@ final class PingMiddlewareTest extends TestingFramework\Core\Functional\Function
         self::assertNotSame(200, $response->getStatusCode());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function middlewareIsSkippedOnNonMatchingRoute(): void
     {
         $request = self::createRequest('/');

--- a/Tests/Functional/Middleware/SolutionMiddlewareTest.php
+++ b/Tests/Functional/Middleware/SolutionMiddlewareTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Functional\Middleware;
 
 use EliasHaeussler\Typo3Solver\Tests;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -43,7 +42,9 @@ final class SolutionMiddlewareTest extends TestingFramework\Core\Functional\Func
 
     protected bool $initializeDatabase = false;
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function middlewareIsSkippedOnUnsupportedRequest(): void
     {
         $request = self::createRequest('/tx_solver/solution')->withoutHeader('Accept');
@@ -52,7 +53,9 @@ final class SolutionMiddlewareTest extends TestingFramework\Core\Functional\Func
         self::assertNotSame(200, $response->getStatusCode());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function middlewareIsSkippedOnNonMatchingRoute(): void
     {
         $request = self::createRequest('/');
@@ -61,7 +64,9 @@ final class SolutionMiddlewareTest extends TestingFramework\Core\Functional\Func
         self::assertNotSame(200, $response->getStatusCode());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function middlewareReturnsEarlyIfNoExceptionIdentifierIsGiven(): void
     {
         $request = self::createRequest('/tx_solver/solution');

--- a/Tests/Functional/ViewHelpers/DateViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/DateViewHelperTest.php
@@ -27,7 +27,6 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use EliasHaeussler\Typo3Solver\Tests;
 use Generator;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function trim;
@@ -48,7 +47,9 @@ final class DateViewHelperTest extends TestingFramework\Core\Functional\Function
 
     protected bool $initializeDatabase = false;
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function renderStaticReturnsNonReadableFormattedDate(): void
     {
         $date = new DateTimeImmutable();
@@ -63,10 +64,10 @@ final class DateViewHelperTest extends TestingFramework\Core\Functional\Function
     }
 
     /**
+     * @test
+     * @dataProvider renderStaticReturnsHumanReadableDateDataProvider
      * @param non-empty-string $expected
      */
-    #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('renderStaticReturnsHumanReadableDateDataProvider')]
     public function renderStaticReturnsHumanReadableDate(DateTimeInterface $date, string $expected): void
     {
         $view = $this->createView('<s:date date="{date}" readable="1" />');

--- a/Tests/Functional/ViewHelpers/MarkdownToHtmlViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/MarkdownToHtmlViewHelperTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Functional\ViewHelpers;
 
 use EliasHaeussler\Typo3Solver\Tests;
 use Parsedown;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function trim;
@@ -56,7 +55,9 @@ final class MarkdownToHtmlViewHelperTest extends TestingFramework\Core\Functiona
         $this->parsedown = new Parsedown();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function renderStaticConvertsMarkdownToHtml(): void
     {
         $markdown = <<<'MARKDOWN'
@@ -74,7 +75,9 @@ MARKDOWN;
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function renderStaticCanBeUsedWithContentArgument(): void
     {
         $markdown = <<<'MARKDOWN'
@@ -92,7 +95,9 @@ MARKDOWN;
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function renderStaticReplacesLinNumbersInCodeSnippets(): void
     {
         $markdown = <<<'MARKDOWN'

--- a/Tests/Unit/Cache/ExceptionsCacheTest.php
+++ b/Tests/Unit/Cache/ExceptionsCacheTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Cache;
 
 use EliasHaeussler\Typo3Solver as Src;
 use Exception;
-use PHPUnit\Framework;
 use Symfony\Component\Filesystem;
 use TYPO3\TestingFramework;
 
@@ -50,7 +49,9 @@ final class ExceptionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->exception = new Exception('Something went wrong.', 123);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function constructorCreatesCacheFileIfNotExists(): void
     {
         $cacheFile = dirname(__DIR__, 3) . '/var/cache/data/tx_solver/exceptions.php';
@@ -66,7 +67,9 @@ final class ExceptionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame([], require $cacheFile);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getReturnsNullOnEmptyCache(): void
     {
         $this->subject->flush();
@@ -74,7 +77,9 @@ final class ExceptionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->get('foo'));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getReturnsNullOnMissingCacheEntry(): void
     {
         $this->subject->flush();
@@ -84,7 +89,9 @@ final class ExceptionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->get('foo'));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getReturnsCacheEntry(): void
     {
         $this->subject->flush();
@@ -99,7 +106,9 @@ final class ExceptionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame($this->exception->getLine(), $actual->getLine());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function removeRemovesGivenExceptionFromCache(): void
     {
         $this->subject->set($this->exception);

--- a/Tests/Unit/Cache/Serializer/ExceptionSerializerTest.php
+++ b/Tests/Unit/Cache/Serializer/ExceptionSerializerTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Cache\Serializer;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -44,7 +43,9 @@ final class ExceptionSerializerTest extends TestingFramework\Core\Unit\UnitTestC
         $this->subject = new Src\Cache\Serializer\ExceptionSerializer();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function serializeReturnsSerializedException(): void
     {
         $exception = Src\Exception\CustomSolvableException::create(
@@ -67,7 +68,9 @@ final class ExceptionSerializerTest extends TestingFramework\Core\Unit\UnitTestC
         self::assertSame($expected, $this->subject->serialize($exception));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function deserializeReturnsDeserializedException(): void
     {
         $exceptionArray = [

--- a/Tests/Unit/Cache/Serializer/SolutionSerializerTest.php
+++ b/Tests/Unit/Cache/Serializer/SolutionSerializerTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Cache\Serializer;
 
 use DateTimeImmutable;
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function time;
@@ -49,7 +48,9 @@ final class SolutionSerializerTest extends TestingFramework\Core\Unit\UnitTestCa
         $this->configuration = new Src\Configuration\Configuration();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function serializeReturnsSerializedSolution(): void
     {
         $solution = Src\Tests\Unit\DataProvider\SolutionDataProvider::get();
@@ -61,7 +62,9 @@ final class SolutionSerializerTest extends TestingFramework\Core\Unit\UnitTestCa
         self::assertGreaterThanOrEqual(time() + $this->configuration->getCacheLifetime(), $actual['validUntil']);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function deserializeReturnsNullIfSolutionIsExpired(): void
     {
         $solutionArray = [
@@ -73,7 +76,9 @@ final class SolutionSerializerTest extends TestingFramework\Core\Unit\UnitTestCa
         self::assertNull($this->subject->deserialize($solutionArray));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function deserializeReturnsDeserializedSolution(): void
     {
         $solution = Src\Tests\Unit\DataProvider\SolutionDataProvider::get();

--- a/Tests/Unit/Cache/SolutionsCacheTest.php
+++ b/Tests/Unit/Cache/SolutionsCacheTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Cache;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use Symfony\Component\Filesystem;
 use TYPO3\TestingFramework;
 
@@ -51,7 +50,9 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->solution = Src\Tests\Unit\DataProvider\SolutionDataProvider::get();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function constructorCreatesCacheFileIfNotExists(): void
     {
         $cacheFile = dirname(__DIR__, 3) . '/var/cache/data/tx_solver/solutions.php';
@@ -67,7 +68,9 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame([], require $cacheFile);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getReturnsNullOnEmptyCache(): void
     {
         $this->subject->flush();
@@ -75,7 +78,9 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->get($this->problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getReturnsCacheEntry(): void
     {
         $this->subject->flush();
@@ -94,7 +99,9 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertEquals($expected, $actual);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getRemovesExpiredCacheEntryAndReturnsNull(): void
     {
         // Manipulate cache lifetime
@@ -112,7 +119,9 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->get($this->problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function setDoesNothingIfSolutionProviderIsNotCacheable(): void
     {
         // Disable cache
@@ -125,7 +134,9 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->get($this->problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function setDoesNothingIfCacheIsDisabled(): void
     {
         $this->subject->flush();
@@ -141,7 +152,9 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->get($this->problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function removeRemovesGivenExceptionFromCache(): void
     {
         $this->subject->set($this->problem, $this->solution);

--- a/Tests/Unit/Command/CacheFlushCommandTest.php
+++ b/Tests/Unit/Command/CacheFlushCommandTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Command;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use Symfony\Component\Console;
 use TYPO3\TestingFramework;
 
@@ -51,7 +50,9 @@ final class CacheFlushCommandTest extends TestingFramework\Core\Unit\UnitTestCas
         $this->cache->flush();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeRemovesSpecificCacheEntryFromCache(): void
     {
         $problem = Src\Tests\Unit\DataProvider\ProblemDataProvider::get();
@@ -74,7 +75,9 @@ final class CacheFlushCommandTest extends TestingFramework\Core\Unit\UnitTestCas
         self::assertNull($this->cache->get($problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeFlushesCompleteCache(): void
     {
         $problem1 = Src\Tests\Unit\DataProvider\ProblemDataProvider::get('message 1');

--- a/Tests/Unit/Command/SolveCommandTest.php
+++ b/Tests/Unit/Command/SolveCommandTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Command;
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
 use Exception;
-use PHPUnit\Framework;
 use Symfony\Component\Console;
 use TYPO3\TestingFramework;
 
@@ -68,7 +67,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->solutionsCache->flush();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeThrowsExceptionIfConflictingParametersAreGiven(): void
     {
         $this->expectExceptionObject(
@@ -81,7 +82,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         ]);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeThrowsExceptionIfExceptionCacheEntryForGivenCacheIdentifierDoesNotExist(): void
     {
         $this->expectExceptionObject(
@@ -91,7 +94,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->commandTester->execute(['--identifier' => 'foo']);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeProvidesSolutionForGivenExceptionIdentifier(): void
     {
         $exception = new Exception('Something went wrong.', 123);
@@ -110,7 +115,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeProvidesSolutionForGivenReconstructedProblem(): void
     {
         $exception = Src\Exception\CustomSolvableException::create(
@@ -137,7 +144,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeThrowsExceptionIfRequiredParametersAreMissing(): void
     {
         $this->expectExceptionObject(
@@ -147,7 +156,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->commandTester->execute([]);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeRemovesCacheEntryWithRefreshOption(): void
     {
         $exception = Src\Exception\CustomSolvableException::create(
@@ -171,7 +182,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNotEquals($solution->getChoices(), $this->solutionsCache->get($problem)->getChoices());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeFailsIfProviderCannotBeUsed(): void
     {
         $exception = new Exception('Something went wrong.');
@@ -187,7 +200,9 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function executeUsesJsonFormatterWithJsonOption(): void
     {
         $solution = Tests\Unit\DataProvider\SolutionDataProvider::get();

--- a/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/Tests/Unit/Configuration/ConfigurationTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Configuration;
 
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -47,13 +46,17 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->subject = new Src\Configuration\Configuration($this->configurationProvider);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getApiKeyReturnsNullIfNoApiKeyIsConfigured(): void
     {
         self::assertNull($this->subject->getApiKey());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getApiKeyReturnsNullIfConfiguredApiKeyIsInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -63,7 +66,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->getApiKey());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getApiKeyReturnsConfiguredApiKey(): void
     {
         $this->configurationProvider->configuration = [
@@ -73,13 +78,17 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame('foo', $this->subject->getApiKey());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getModelReturnsDefaultModelIfNoModelIsConfigured(): void
     {
         self::assertSame('gpt-3.5-turbo-0301', $this->subject->getModel());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getModelReturnsDefaultModelIfConfiguredModelIsInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -89,7 +98,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame('gpt-3.5-turbo-0301', $this->subject->getModel());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getModelReturnsConfiguredModel(): void
     {
         $this->configurationProvider->configuration = [
@@ -99,13 +110,17 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame('foo', $this->subject->getModel());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getMaxTokensReturnsDefaultMaxTokensIfNoMaxTokensAreConfigured(): void
     {
         self::assertSame(300, $this->subject->getMaxTokens());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getMaxTokensReturnsDefaultMaxTokensIfConfiguredMaxTokensAreInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -115,7 +130,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(300, $this->subject->getMaxTokens());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getMaxTokensReturnsConfiguredMaxTokens(): void
     {
         $this->configurationProvider->configuration = [
@@ -125,13 +142,17 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(150, $this->subject->getMaxTokens());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getTemperatureReturnsDefaultTemperatureIfNoTemperatureIsConfigured(): void
     {
         self::assertSame(0.5, $this->subject->getTemperature());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getTemperatureReturnsDefaultTemperatureIfConfiguredTemperatureIsInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -141,7 +162,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(0.5, $this->subject->getTemperature());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getTemperatureReturnsConfiguredTemperature(): void
     {
         $this->configurationProvider->configuration = [
@@ -151,13 +174,17 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(0.75, $this->subject->getTemperature());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getNumberOfCompletionsReturnsDefaultNumberOfCompletionsIfNoNumberOfCompletionsIsConfigured(): void
     {
         self::assertSame(1, $this->subject->getNumberOfCompletions());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getNumberOfCompletionsReturnsDefaultNumberOfCompletionsIfConfiguredNumberOfCompletionsIsInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -167,7 +194,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(1, $this->subject->getNumberOfCompletions());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getNumberOfCompletionsReturnsConfiguredNumberOfCompletions(): void
     {
         $this->configurationProvider->configuration = [
@@ -177,13 +206,17 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(5, $this->subject->getNumberOfCompletions());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getCacheLifetimeReturnsDefaultCacheLifetimeIfNoCacheLifetimeIsConfigured(): void
     {
         self::assertSame(60 * 60 * 24, $this->subject->getCacheLifetime());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getCacheLifetimeReturnsDefaultCacheLifetimeIfConfiguredCacheLifetimeIsInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -193,7 +226,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(60 * 60 * 24, $this->subject->getCacheLifetime());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getCacheLifetimeReturnsConfiguredCacheLifetime(): void
     {
         $this->configurationProvider->configuration = [
@@ -203,7 +238,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(3600, $this->subject->getCacheLifetime());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getProviderReturnsDefaultProviderIfNoProviderIsConfigured(): void
     {
         self::assertInstanceOf(
@@ -212,7 +249,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getProviderReturnsDefaultProviderIfConfiguredProviderIsInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -225,7 +264,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getProviderReturnsConfiguredProvider(): void
     {
         $this->configurationProvider->configuration = [
@@ -238,7 +279,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getPromptReturnsDefaultPromptIfNoPromptIsConfigured(): void
     {
         self::assertInstanceOf(
@@ -247,7 +290,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getPromptReturnsDefaultPromptIfConfiguredPromptIsInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -260,7 +305,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getPromptReturnsConfiguredPrompt(): void
     {
         $this->configurationProvider->configuration = [
@@ -273,13 +320,17 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getIgnoredCodesReturnsEmptyArrayIfCodesToIgnoreAreNotConfigured(): void
     {
         self::assertSame([], $this->subject->getIgnoredCodes());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getIgnoredCodesReturnsEmptyArrayIfCodesToIgnoreAreInvalid(): void
     {
         $this->configurationProvider->configuration = [
@@ -289,7 +340,9 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame([], $this->subject->getIgnoredCodes());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getIgnoredCodesReturnsConfiguredCodesToIgnore(): void
     {
         $this->configurationProvider->configuration = [

--- a/Tests/Unit/Exception/ApiKeyMissingExceptionTest.php
+++ b/Tests/Unit/Exception/ApiKeyMissingExceptionTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -35,7 +34,9 @@ use TYPO3\TestingFramework;
  */
 final class ApiKeyMissingExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function createReturnsExceptionForMissingApiKey(): void
     {
         $actual = Src\Exception\ApiKeyMissingException::create();

--- a/Tests/Unit/Exception/CustomSolvableExceptionTest.php
+++ b/Tests/Unit/Exception/CustomSolvableExceptionTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -35,7 +34,9 @@ use TYPO3\TestingFramework;
  */
 final class CustomSolvableExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function createReturnsCustomSolvableException(): void
     {
         $actual = Src\Exception\CustomSolvableException::create(

--- a/Tests/Unit/Exception/EventStreamExceptionTest.php
+++ b/Tests/Unit/Exception/EventStreamExceptionTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -35,7 +34,9 @@ use TYPO3\TestingFramework;
  */
 final class EventStreamExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function forActiveResponseReturnsExceptionForActiveResponse(): void
     {
         $actual = Src\Exception\EventStreamException::forActiveResponse();
@@ -44,7 +45,9 @@ final class EventStreamExceptionTest extends TestingFramework\Core\Unit\UnitTest
         self::assertSame(1680364482, $actual->getCode());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function forClosedStreamReturnsExceptionForClosedStream(): void
     {
         $actual = Src\Exception\EventStreamException::forClosedStream();

--- a/Tests/Unit/Exception/IOExceptionTest.php
+++ b/Tests/Unit/Exception/IOExceptionTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -35,7 +34,9 @@ use TYPO3\TestingFramework;
  */
 final class IOExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function forConflictingParametersReturnsExceptionForConflictingParameters(): void
     {
         $actual = Src\Exception\IOException::forConflictingParameters('foo', 'baz');
@@ -44,7 +45,9 @@ final class IOExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame(1680388489, $actual->getCode());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function forMissingRequiredParameterReturnsExceptionForMissingRequiredParameter(): void
     {
         $actual = Src\Exception\IOException::forMissingRequiredParameter('foo');

--- a/Tests/Unit/Exception/MissingCacheEntryExceptionTest.php
+++ b/Tests/Unit/Exception/MissingCacheEntryExceptionTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -35,7 +34,9 @@ use TYPO3\TestingFramework;
  */
 final class MissingCacheEntryExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function createReturnsExceptionForMissingCacheEntry(): void
     {
         $actual = Src\Exception\MissingCacheEntryException::create('foo');

--- a/Tests/Unit/Exception/UnableToSolveExceptionTest.php
+++ b/Tests/Unit/Exception/UnableToSolveExceptionTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Exception;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function sprintf;
@@ -37,7 +36,9 @@ use function sprintf;
  */
 final class UnableToSolveExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function createReturnsExceptionForGivenProblem(): void
     {
         $problem = Src\Tests\Unit\DataProvider\ProblemDataProvider::get();

--- a/Tests/Unit/Formatter/CliFormatterTest.php
+++ b/Tests/Unit/Formatter/CliFormatterTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Formatter;
 
 use DateTimeImmutable;
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use Symfony\Component\Console;
 use TYPO3\TestingFramework;
 
@@ -48,7 +47,9 @@ final class CliFormatterTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->subject = new Src\Formatter\CliFormatter();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function formatFormatsSolution(): void
     {
         $now = new DateTimeImmutable();
@@ -79,7 +80,9 @@ TEXT;
         self::assertSame(trim($expected), $this->subject->format($problem, $solution));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function formatIncludesPromptIfOutputIsVerbose(): void
     {
         $output = new Console\Output\BufferedOutput();

--- a/Tests/Unit/Formatter/JsonFormatterTest.php
+++ b/Tests/Unit/Formatter/JsonFormatterTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Formatter;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function json_encode;
@@ -46,7 +45,9 @@ final class JsonFormatterTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->subject = new Src\Formatter\JsonFormatter();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function formatReturnsJsonSerializedSolution(): void
     {
         $problem = Src\Tests\Unit\DataProvider\ProblemDataProvider::get();

--- a/Tests/Unit/Formatter/Message/ExceptionFormatterTest.php
+++ b/Tests/Unit/Formatter/Message/ExceptionFormatterTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Formatter\Message;
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
 use Exception;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -48,7 +47,9 @@ final class ExceptionFormatterTest extends TestingFramework\Core\Unit\UnitTestCa
         $this->subject = new Src\Formatter\Message\ExceptionFormatter();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function formatReturnsFormattedException(): void
     {
         $exception = new Exception('Something went wrong.', 123);

--- a/Tests/Unit/Formatter/Message/ExceptionStreamFormatterTest.php
+++ b/Tests/Unit/Formatter/Message/ExceptionStreamFormatterTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Formatter\Message;
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
 use Exception;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -48,7 +47,9 @@ final class ExceptionStreamFormatterTest extends TestingFramework\Core\Unit\Unit
         $this->subject = new Src\Formatter\Message\ExceptionStreamFormatter();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function formatReturnsJsonEncodedExceptionStream(): void
     {
         $exception = new Exception('Something went wrong.', 123);

--- a/Tests/Unit/Formatter/WebFormatterTest.php
+++ b/Tests/Unit/Formatter/WebFormatterTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Formatter;
 
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function dirname;
@@ -53,7 +52,9 @@ final class WebFormatterTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->exceptionsCache = new Src\Cache\ExceptionsCache();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function formatReturnsFormattedSolution(): void
     {
         $problem = Src\Tests\Unit\DataProvider\ProblemDataProvider::get();
@@ -100,7 +101,9 @@ final class WebFormatterTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNodeContentEqualsString('prompt', '//form/details[1]/pre[1]/text()', $xpath);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getAdditionalStylesReturnsAdditionalStylesheet(): void
     {
         self::assertStringEqualsFile(
@@ -109,7 +112,9 @@ final class WebFormatterTest extends TestingFramework\Core\Unit\UnitTestCase
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getAdditionalScriptsReturnsAdditionalJavaScript(): void
     {
         self::assertStringEqualsFile(

--- a/Tests/Unit/Formatter/WebStreamFormatterTest.php
+++ b/Tests/Unit/Formatter/WebStreamFormatterTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\Formatter;
 
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function json_decode;
@@ -49,7 +48,9 @@ final class WebStreamFormatterTest extends TestingFramework\Core\Unit\UnitTestCa
         $this->subject = new Src\Formatter\WebStreamFormatter();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function formatReturnsJsonEncodedSolutionStream(): void
     {
         $problem = Src\Tests\Unit\DataProvider\ProblemDataProvider::get();

--- a/Tests/Unit/ProblemSolving/Problem/ProblemTest.php
+++ b/Tests/Unit/ProblemSolving/Problem/ProblemTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Problem;
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
 use Exception;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -50,19 +49,25 @@ final class ProblemTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->subject = new Src\ProblemSolving\Problem\Problem($this->exception, $this->provider, 'foo');
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getExceptionReturnsException(): void
     {
         self::assertSame($this->exception, $this->subject->getException());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionProviderReturnsSolutionProvider(): void
     {
         self::assertSame($this->provider, $this->subject->getSolutionProvider());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getPromptReturnsPrompt(): void
     {
         self::assertSame('foo', $this->subject->getPrompt());

--- a/Tests/Unit/ProblemSolving/Prompt/DefaultPromptTest.php
+++ b/Tests/Unit/ProblemSolving/Prompt/DefaultPromptTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Prompt;
 
 use EliasHaeussler\Typo3Solver as Src;
 use Exception;
-use PHPUnit\Framework;
 use TYPO3\CMS\Core;
 use TYPO3\TestingFramework;
 
@@ -46,7 +45,9 @@ final class DefaultPromptTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->subject = new Src\ProblemSolving\Solution\Prompt\DefaultPrompt();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function generateReturnsGeneratedPrompt(): void
     {
         $exception = new Exception('Something went wrong.', 1680791875);

--- a/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Solution\Provider
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
 use Exception;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function iterator_to_array;
@@ -54,7 +53,9 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         $this->cache->flush();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionReturnsSolutionFromCache(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);
@@ -67,7 +68,9 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         self::assertEquals($this->cache->get($problem), $actual);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionReturnsSolutionFromProviderAndStoresItInCache(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);
@@ -83,7 +86,9 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         self::assertNotNull($this->cache->get($problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getStreamedSolutionYieldsSolutionFromCache(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);
@@ -97,7 +102,9 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         self::assertEquals([$this->cache->get($problem)], $actual);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getStreamedSolutionYieldsSolutionFromNonStreamedProvider(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);
@@ -113,7 +120,9 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         self::assertSame([$solution], $actual);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getStreamedSolutionYieldsSolutionsFromProvider(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);
@@ -131,7 +140,9 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         self::assertEquals($expected2, $actual[1]);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function canBeUsedDelegatesRequestToProvider(): void
     {
         $exception = new Exception();
@@ -145,13 +156,17 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
         self::assertFalse($this->subject->canBeUsed($exception));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function isCacheableReturnsTrue(): void
     {
         self::assertTrue($this->subject->isCacheable());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getProviderReturnsProvider(): void
     {
         self::assertSame($this->provider, $this->subject->getProvider());

--- a/Tests/Unit/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProviderTest.php
@@ -27,7 +27,6 @@ use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
 use Exception;
 use OpenAI\Responses;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -53,7 +52,9 @@ final class DelegatingCacheSolutionProviderTest extends TestingFramework\Core\Un
         $this->cache->flush();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionReturnsSolutionFromCache(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);
@@ -77,7 +78,9 @@ final class DelegatingCacheSolutionProviderTest extends TestingFramework\Core\Un
         self::assertEquals($solution, $actual);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionReturnsDummySolution(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);
@@ -90,13 +93,17 @@ final class DelegatingCacheSolutionProviderTest extends TestingFramework\Core\Un
         self::assertEquals($this->cache->get($problem), $actual);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function canBeUsedReturnsTrue(): void
     {
         self::assertTrue($this->subject->canBeUsed(new Exception()));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function isCacheableReturnsFalse(): void
     {
         self::assertFalse($this->subject->isCacheable());

--- a/Tests/Unit/ProblemSolving/Solution/Provider/OpenAISolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/OpenAISolutionProviderTest.php
@@ -30,7 +30,6 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Handler;
 use GuzzleHttp\Psr7;
 use OpenAI;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function iterator_to_array;
@@ -67,7 +66,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Src\Extension::KEY]['api']['key'] = 'foo';
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionThrowsExceptionIfApiKeyIsNotConfigured(): void
     {
         /* @phpstan-ignore-next-line */
@@ -80,7 +81,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         $this->subject->getSolution($this->problem);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionThrowsExceptionIfRequestFails(): void
     {
         $this->expectExceptionObject(
@@ -92,7 +95,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         $this->subject->getSolution($this->problem);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getSolutionReturnsSolutionFromClientResponse(): void
     {
         $payload = [
@@ -128,7 +133,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         );
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getStreamedSolutionThrowsExceptionIfApiKeyIsNotConfigured(): void
     {
         /* @phpstan-ignore-next-line */
@@ -141,7 +148,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         iterator_to_array($this->subject->getStreamedSolution($this->problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getStreamedSolutionThrowsExceptionIfRequestFails(): void
     {
         $this->expectExceptionObject(
@@ -153,7 +162,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         iterator_to_array($this->subject->getStreamedSolution($this->problem));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getStreamedSolutionReturnsSolutionFromClientResponse(): void
     {
         $streamedResponse1 = [
@@ -204,7 +215,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         self::assertEquals($expected, iterator_to_array($this->subject->getStreamedSolution($this->problem)));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function canBeUsedChecksIfIgnoredExceptionCodesAreConfigured(): void
     {
         /* @phpstan-ignore-next-line */
@@ -218,7 +231,9 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         self::assertTrue($this->subject->canBeUsed($this->problem->getException()));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function isCacheableReturnsTrue(): void
     {
         self::assertTrue($this->subject->isCacheable());

--- a/Tests/Unit/ProblemSolving/Solution/SolutionTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/SolutionTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Solution;
 use DateTimeImmutable;
 use EliasHaeussler\Typo3Solver as Src;
 use OpenAI\Responses;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function iterator_to_array;
@@ -58,7 +57,9 @@ final class SolutionTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->subject = new Src\ProblemSolving\Solution\Solution([$this->choice], 'foo', 'baz');
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function fromResponseReturnsSolution(): void
     {
         $response = Responses\Chat\CreateResponse::from([
@@ -98,7 +99,9 @@ final class SolutionTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertEquals([$choice], $actual->getChoices());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function fromArrayReturnsSolution(): void
     {
         $solution = [
@@ -148,7 +151,9 @@ final class SolutionTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertEquals([$choice1, $choice2], $actual->getChoices());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function setCreateDateAppliesCreateDate(): void
     {
         self::assertNull($this->subject->getCreateDate());
@@ -158,26 +163,34 @@ final class SolutionTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame($createDate, $this->subject->setCreateDate($createDate)->getCreateDate());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function setCacheIdentifierAppliesCacheIdentifier(): void
     {
         self::assertNull($this->subject->getCacheIdentifier());
         self::assertSame('foo', $this->subject->setCacheIdentifier('foo')->getCacheIdentifier());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function subjectIsCountable(): void
     {
         self::assertCount(1, $this->subject);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function subjectIsIterable(): void
     {
         self::assertSame([$this->choice], iterator_to_array($this->subject));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function toArrayReturnsArrayRepresentation(): void
     {
         $expected = [
@@ -191,7 +204,9 @@ final class SolutionTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame($expected, $this->subject->toArray());
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function subjectIsJsonSerializable(): void
     {
         $expected = [

--- a/Tests/Unit/ProblemSolving/SolverTest.php
+++ b/Tests/Unit/ProblemSolving/SolverTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving;
 use EliasHaeussler\Typo3Solver as Src;
 use EliasHaeussler\Typo3Solver\Tests;
 use Exception;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function iterator_to_array;
@@ -53,7 +52,9 @@ final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
         (new Src\Cache\SolutionsCache())->flush();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function solveReturnsNullIfProviderCannotBeUsed(): void
     {
         $this->provider->shouldBeUsed = false;
@@ -61,7 +62,9 @@ final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertNull($this->subject->solve(new Exception()));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function solveReturnsFormattedSolution(): void
     {
         $dummySolution = Tests\Unit\DataProvider\SolutionDataProvider::get();
@@ -74,7 +77,9 @@ final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertJsonStringEqualsJsonString(json_encode($dummySolution, JSON_THROW_ON_ERROR), $actual);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function solveStreamedYieldsEmptySolutionStreamIfProviderCannotBeUsed(): void
     {
         $this->provider->shouldBeUsed = false;
@@ -82,7 +87,9 @@ final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame([], iterator_to_array($this->subject->solveStreamed(new Exception())));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function solveStreamedYieldsFormattedSolutionStreams(): void
     {
         $solutions = iterator_to_array(Tests\Unit\DataProvider\SolutionDataProvider::getStream());

--- a/Tests/Unit/Utility/HttpUtilityTest.php
+++ b/Tests/Unit/Utility/HttpUtilityTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Utility;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\CMS\Core;
 use TYPO3\TestingFramework;
 
@@ -36,7 +35,9 @@ use TYPO3\TestingFramework;
  */
 final class HttpUtilityTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function uriMatchesRequestReturnsTrueIfGivenRoutePathMatchesRequestUri(): void
     {
         $routePath = '/foo';
@@ -45,7 +46,9 @@ final class HttpUtilityTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertTrue(Src\Utility\HttpUtility::uriMatchesRequest($routePath, $request));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function uriMatchesRequestReturnsFalseIfGivenRoutePathDoesNotMatchRequestUri(): void
     {
         $routePath = '/foo';
@@ -54,7 +57,9 @@ final class HttpUtilityTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertFalse(Src\Utility\HttpUtility::uriMatchesRequest($routePath, $request));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getServerRequestReturnsGlobalServerRequest(): void
     {
         $request = new Core\Http\ServerRequest();
@@ -66,7 +71,9 @@ final class HttpUtilityTest extends TestingFramework\Core\Unit\UnitTestCase
         unset($GLOBALS['TYPO3_REQUEST']);
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function getServerRequestCreatesServerRequestIfNoGlobalServerRequestIsAvailable(): void
     {
         $emptyStream = new Core\Http\Stream('php://temp');

--- a/Tests/Unit/Utility/StringUtilityTest.php
+++ b/Tests/Unit/Utility/StringUtilityTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\Tests\Unit\Utility;
 
 use EliasHaeussler\Typo3Solver as Src;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 /**
@@ -35,7 +34,9 @@ use TYPO3\TestingFramework;
  */
 final class StringUtilityTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function replaceFirstOccurrenceDoesNothingIfSearchedStringDoesNotExistInSubject(): void
     {
         $subject = 'foo baz foo baz';
@@ -43,7 +44,9 @@ final class StringUtilityTest extends TestingFramework\Core\Unit\UnitTestCase
         self::assertSame($subject, Src\Utility\StringUtility::replaceFirstOccurrence('x', 'y', $subject));
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function replaceFirstOccurrenceReplacesFirstOccurrenceOfSearchedStringInSubject(): void
     {
         $subject = 'foo baz foo baz';

--- a/Tests/Unit/View/TemplateRendererTest.php
+++ b/Tests/Unit/View/TemplateRendererTest.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\Typo3Solver\Tests\Unit\View;
 
 use EliasHaeussler\Typo3Solver as Src;
 use Exception;
-use PHPUnit\Framework;
 use TYPO3\TestingFramework;
 
 use function trim;
@@ -47,7 +46,9 @@ final class TemplateRendererTest extends TestingFramework\Core\Unit\UnitTestCase
         $this->subject = new Src\View\TemplateRenderer();
     }
 
-    #[Framework\Attributes\Test]
+    /**
+     * @test
+     */
     public function renderRendersTemplateWithGivenVariables(): void
     {
         $file = __FILE__;

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan-symfony": "^1.2",
 		"phpunit/phpcov": "^8.2 || ^9.0",
-		"phpunit/phpunit": "^10.0",
+		"phpunit/phpunit": "^9.6",
 		"saschaegerer/phpstan-typo3": "^1.8",
 		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
 		"symfony/dependency-injection": "^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan-symfony": "^1.2",
 		"phpunit/phpcov": "^8.2 || ^9.0",
+		"phpunit/phpunit": "^10.0",
 		"saschaegerer/phpstan-typo3": "^1.8",
 		"sbuerk/typo3-cmscomposerinstallers-testingframework-bridge": "^0.1.2",
 		"symfony/dependency-injection": "^5.4 || ^6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98ea9f6b1fb7507391ce1bec47093a57",
+    "content-hash": "597860e8fa06ae18ea1d84c817d8762f",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "597860e8fa06ae18ea1d84c817d8762f",
+    "content-hash": "fb8a33b8110efc320d10b9e4b80db852",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5487,6 +5487,76 @@
             "time": "2022-02-25T21:32:43+00:00"
         },
         {
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
             "name": "eliashaeussler/phpstan-config",
             "version": "1.0.2",
             "source": {
@@ -7022,16 +7092,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.0.2",
+            "version": "9.2.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "20800e84296ea4732f9a125e08ce86b4004ae3e4"
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/20800e84296ea4732f9a125e08ce86b4004ae3e4",
-                "reference": "20800e84296ea4732f9a125e08ce86b4004ae3e4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
+                "reference": "443bc6912c9bd5b409254a40f4b0f4ced7c80ea1",
                 "shasum": ""
             },
             "require": {
@@ -7039,18 +7109,18 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^4.15",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^3.0",
-                "sebastian/complexity": "^3.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/lines-of-code": "^2.0",
-                "sebastian/version": "^4.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.3",
+                "phpunit/php-text-template": "^2.0.2",
+                "sebastian/code-unit-reverse-lookup": "^2.0.2",
+                "sebastian/complexity": "^2.0",
+                "sebastian/environment": "^5.1.2",
+                "sebastian/lines-of-code": "^1.0.3",
+                "sebastian/version": "^3.0.1",
                 "theseer/tokenizer": "^1.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -7059,7 +7129,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.0-dev"
+                    "dev-master": "9.2-dev"
                 }
             },
             "autoload": {
@@ -7087,7 +7157,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.0.2"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.26"
             },
             "funding": [
                 {
@@ -7095,32 +7165,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-06T13:00:19+00:00"
+            "time": "2023-03-06T12:58:08+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.0.1",
+            "version": "3.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd"
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
-                "reference": "fd9329ab3368f59fe1fe808a189c51086bd4b6bd",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -7147,7 +7217,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
             },
             "funding": [
                 {
@@ -7155,28 +7225,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-10T16:53:14+00:00"
+            "time": "2021-12-02T12:48:52+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -7184,7 +7254,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -7210,7 +7280,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
             },
             "funding": [
                 {
@@ -7218,32 +7288,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2020-09-28T05:58:55+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.0",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d"
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
-                "reference": "9f3d3709577a527025f55bcf0f7ab8052c8bb37d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -7269,7 +7339,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
             },
             "funding": [
                 {
@@ -7277,32 +7347,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:46+00:00"
+            "time": "2020-10-26T05:33:50+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -7328,7 +7398,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
             },
             "funding": [
                 {
@@ -7336,30 +7406,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2020-10-26T13:16:10+00:00"
         },
         {
             "name": "phpunit/phpcov",
-            "version": "9.0.0",
+            "version": "8.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpcov.git",
-                "reference": "e314a94c87176732267056b497e5a88931db90cc"
+                "reference": "8ec45dde34a84914a0ace355fbd6d7af2242c9a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/e314a94c87176732267056b497e5a88931db90cc",
-                "reference": "e314a94c87176732267056b497e5a88931db90cc",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpcov/zipball/8ec45dde34a84914a0ace355fbd6d7af2242c9a4",
+                "reference": "8ec45dde34a84914a0ace355fbd6d7af2242c9a4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.0",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/phpunit": "^10.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/version": "^4.0"
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2",
+                "phpunit/php-file-iterator": "^3.0",
+                "phpunit/phpunit": "^9.3",
+                "sebastian/cli-parser": "^1.0",
+                "sebastian/diff": "^4.0",
+                "sebastian/version": "^3.0"
             },
             "bin": [
                 "phpcov"
@@ -7367,7 +7437,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "9.0-dev"
+                    "dev-master": "8.2-dev"
                 }
             },
             "autoload": {
@@ -7390,7 +7460,7 @@
             "homepage": "https://github.com/sebastianbergmann/phpcov",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpcov/issues",
-                "source": "https://github.com/sebastianbergmann/phpcov/tree/9.0.0"
+                "source": "https://github.com/sebastianbergmann/phpcov/tree/8.2.1"
             },
             "funding": [
                 {
@@ -7398,23 +7468,24 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-13T08:45:44+00:00"
+            "time": "2022-03-24T12:07:05+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.0.19",
+            "version": "9.6.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62"
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/20c23e85c86e5c06d63538ba464e8054f4744e62",
-                "reference": "20c23e85c86e5c06d63538ba464e8054f4744e62",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b65d59a059d3004a040c16a82e07bbdf6cfdd115",
+                "reference": "b65d59a059d3004a040c16a82e07bbdf6cfdd115",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.3.1 || ^2",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
@@ -7424,26 +7495,27 @@
                 "myclabs/deep-copy": "^1.10.1",
                 "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.0",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.0",
-                "sebastian/global-state": "^6.0",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.13",
+                "phpunit/php-file-iterator": "^3.0.5",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.3",
+                "phpunit/php-timer": "^5.0.2",
+                "sebastian/cli-parser": "^1.0.1",
+                "sebastian/code-unit": "^1.0.6",
+                "sebastian/comparator": "^4.0.8",
+                "sebastian/diff": "^4.0.3",
+                "sebastian/environment": "^5.1.3",
+                "sebastian/exporter": "^4.0.5",
+                "sebastian/global-state": "^5.0.1",
+                "sebastian/object-enumerator": "^4.0.3",
+                "sebastian/resource-operations": "^3.0.3",
+                "sebastian/type": "^3.2",
+                "sebastian/version": "^3.0.2"
             },
             "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "bin": [
                 "phpunit"
@@ -7451,7 +7523,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.0-dev"
+                    "dev-master": "9.6-dev"
                 }
             },
             "autoload": {
@@ -7483,7 +7555,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.0.19"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.6"
             },
             "funding": [
                 {
@@ -7499,7 +7571,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-27T11:46:33+00:00"
+            "time": "2023-03-27T11:43:46+00:00"
         },
         {
             "name": "rector/rector",
@@ -7686,28 +7758,28 @@
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "2.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae"
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/efdc130dbbbb8ef0b545a994fd811725c5282cae",
-                "reference": "efdc130dbbbb8ef0b545a994fd811725c5282cae",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -7730,7 +7802,7 @@
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
             },
             "funding": [
                 {
@@ -7738,32 +7810,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:15+00:00"
+            "time": "2020-09-28T06:08:49+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -7786,7 +7858,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
             },
             "funding": [
                 {
@@ -7794,32 +7866,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2020-10-26T13:08:54+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -7841,7 +7913,7 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
             },
             "funding": [
                 {
@@ -7849,36 +7921,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2020-09-28T05:30:19+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.0",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c"
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/72f01e6586e0caf6af81297897bd112eb7e9627c",
-                "reference": "72f01e6586e0caf6af81297897bd112eb7e9627c",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
                 "shasum": ""
             },
             "require": {
-                "ext-dom": "*",
-                "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -7917,7 +7987,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
             },
             "funding": [
                 {
@@ -7925,33 +7995,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:16+00:00"
+            "time": "2022-09-14T12:41:17+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6"
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
-                "reference": "e67d240970c9dc7ea7b2123a6d520e334dd61dc6",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
-                "php": ">=8.1"
+                "nikic/php-parser": "^4.7",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -7974,7 +8044,7 @@
             "homepage": "https://github.com/sebastianbergmann/complexity",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
             },
             "funding": [
                 {
@@ -7982,33 +8052,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:47+00:00"
+            "time": "2020-10-26T15:52:27+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02"
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/aae9a0a43bff37bd5d8d0311426c87bf36153f02",
-                "reference": "aae9a0a43bff37bd5d8d0311426c87bf36153f02",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/3461e3fccc7cfdfc2720be910d3bd73c69be590d",
+                "reference": "3461e3fccc7cfdfc2720be910d3bd73c69be590d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
+                "phpunit/phpunit": "^9.3",
                 "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -8040,8 +8110,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
             },
             "funding": [
                 {
@@ -8049,27 +8118,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-03-23T05:12:41+00:00"
+            "time": "2020-10-26T13:10:38+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.0.0",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc"
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b6f3694c6386c7959915a0037652e0c40f6f69cc",
-                "reference": "b6f3694c6386c7959915a0037652e0c40f6f69cc",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -8077,7 +8146,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.1-dev"
                 }
             },
             "autoload": {
@@ -8096,7 +8165,7 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "https://github.com/sebastianbergmann/environment",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
@@ -8104,7 +8173,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
             },
             "funding": [
                 {
@@ -8112,34 +8181,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:03:04+00:00"
+            "time": "2023-02-03T06:03:51+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.0.0",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0"
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
-                "reference": "f3ec4bf931c0b31e5b413f5b4fc970a7d03338c0",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -8181,7 +8250,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
             },
             "funding": [
                 {
@@ -8189,35 +8258,38 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:49+00:00"
+            "time": "2022-09-14T06:03:37+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.0",
+            "version": "5.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44"
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/aab257c712de87b90194febd52e4d184551c2d44",
-                "reference": "aab257c712de87b90194febd52e4d184551c2d44",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -8242,7 +8314,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.0"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
             },
             "funding": [
                 {
@@ -8250,33 +8322,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:07:38+00:00"
+            "time": "2022-02-14T08:28:10+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.0",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130"
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/17c4d940ecafb3d15d2cf916f4108f664e28b130",
-                "reference": "17c4d940ecafb3d15d2cf916f4108f664e28b130",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.10",
-                "php": ">=8.1"
+                "nikic/php-parser": "^4.6",
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-master": "1.0-dev"
                 }
             },
             "autoload": {
@@ -8299,7 +8371,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.0"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
             },
             "funding": [
                 {
@@ -8307,34 +8379,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:02+00:00"
+            "time": "2020-11-28T06:42:11+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -8356,7 +8428,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
             },
             "funding": [
                 {
@@ -8364,32 +8436,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2020-10-26T13:12:34+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -8411,7 +8483,7 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
             },
             "funding": [
                 {
@@ -8419,32 +8491,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2020-10-26T13:14:26+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.0",
+            "version": "4.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-master": "4.0-dev"
                 }
             },
             "autoload": {
@@ -8474,7 +8546,7 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
             },
             "funding": [
                 {
@@ -8482,32 +8554,87 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:05:40+00:00"
+            "time": "2023-02-03T06:07:39+00:00"
         },
         {
-            "name": "sebastian/type",
-            "version": "4.0.0",
+            "name": "sebastian/resource-operations",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:45:17+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -8530,7 +8657,7 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
             },
             "funding": [
                 {
@@ -8538,29 +8665,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2023-02-03T06:13:03+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=7.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -8583,7 +8710,7 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
             },
             "funding": [
                 {
@@ -8591,7 +8718,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2020-09-28T06:39:44+00:00"
         },
         {
             "name": "symfony/polyfill-php80",

--- a/rector.php
+++ b/rector.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 use EliasHaeussler\RectorConfig\Config\Config;
 use Rector\Config\RectorConfig;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
-use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Privatization\Rector\Class_\ChangeReadOnlyVariableWithDefaultValueToConstantRector;
 use Rector\PSR4\Rector\FileWithoutNamespace\NormalizeNamespaceByPSR4ComposerAutoloadRector;
 use Rector\Symfony\Rector\Class_\CommandPropertyToAttributeRector;
@@ -40,9 +39,6 @@ return static function (RectorConfig $rectorConfig): void {
     $config->withSymfony();
 
     $config->skip(AddLiteralSeparatorToNumberRector::class);
-    $config->skip(AnnotationToAttributeRector::class, [
-        __DIR__ . '/Classes/Extension.php',
-    ]);
     $config->skip(ChangeReadOnlyVariableWithDefaultValueToConstantRector::class);
     $config->skip(CommandPropertyToAttributeRector::class);
     $config->skip(NormalizeNamespaceByPSR4ComposerAutoloadRector::class, [


### PR DESCRIPTION
TYPO3 11.5 cannot be tested with PHPUnit 10, so we're forced to roll back to PHPUnit 9.