### PR TITLE
[TASK] Use PHPStan type of serialized solution from SolutionSerializer

### DIFF
--- a/Classes/Cache/SolutionsCache.php
+++ b/Classes/Cache/SolutionsCache.php
@@ -40,7 +40,7 @@ use function var_export;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  *
- * @phpstan-import-type SolutionArray from ProblemSolving\Solution\Solution
+ * @phpstan-import-type SolutionArray from Serializer\SolutionSerializer
  */
 final class SolutionsCache
 {
@@ -60,7 +60,7 @@ final class SolutionsCache
 
     public function get(ProblemSolving\Problem\Problem $problem): ?ProblemSolving\Solution\Solution
     {
-        /** @phpstan-var array{solutions: array<string, array{solution: SolutionArray, createdAt: int, validUntil: int}>} $cacheData */
+        /** @phpstan-var array{solutions: array<string, SolutionArray>} $cacheData */
         $cacheData = require $this->cachePath;
         $entryIdentifier = $this->calculateCacheIdentifier($problem);
 


### PR DESCRIPTION
The `SolutionSerializer` already provides the complete PHPStan type for serialized solutions. Therefore, we should reuse this type in `SolutionsCache` instead of re-constructing it.