### PR TITLE
[!!!][FEATURE] Use dependency injection where possible

### DIFF
--- a/Classes/Command/ListModelsCommand.php
+++ b/Classes/Command/ListModelsCommand.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\Typo3Solver\Command;
 
-use EliasHaeussler\Typo3Solver\Configuration;
-use OpenAI;
+use OpenAI\Client;
+use OpenAI\Responses;
 use Symfony\Component\Console;
 
 use function array_map;
@@ -38,13 +38,10 @@ use function sort;
  */
 final class ListModelsCommand extends Console\Command\Command
 {
-    private readonly OpenAI\Client $client;
-
-    public function __construct()
-    {
+    public function __construct(
+        private readonly Client $client,
+    ) {
         parent::__construct('solver:list-models');
-
-        $this->client = OpenAI::client((new Configuration\Configuration())->getApiKey() ?? '');
     }
 
     protected function execute(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): int
@@ -52,7 +49,7 @@ final class ListModelsCommand extends Console\Command\Command
         $io = new Console\Style\SymfonyStyle($input, $output);
 
         $models = array_map(
-            static fn (OpenAI\Responses\Models\RetrieveResponse $response): string => $response->id,
+            static fn (Responses\Models\RetrieveResponse $response): string => $response->id,
             $this->client->models()->list()->data,
         );
 

--- a/Classes/Command/SolveCommand.php
+++ b/Classes/Command/SolveCommand.php
@@ -40,20 +40,18 @@ use Throwable;
 final class SolveCommand extends Console\Command\Command
 {
     private readonly ProblemSolving\Solution\Provider\SolutionProvider $solutionProvider;
-    private readonly Formatter\CliFormatter $cliFormatter;
-    private readonly Formatter\JsonFormatter $jsonFormatter;
 
     public function __construct(
         private readonly Configuration\Configuration $configuration,
         private readonly Cache\ExceptionsCache $exceptionsCache,
         private readonly Cache\SolutionsCache $solutionsCache,
+        private readonly Formatter\CliFormatter $cliFormatter,
+        private readonly Formatter\JsonFormatter $jsonFormatter,
         ProblemSolving\Solution\Provider\SolutionProvider $solutionProvider = null,
     ) {
         parent::__construct('solver:solve');
 
         $this->solutionProvider = $solutionProvider ?? $this->configuration->getProvider();
-        $this->cliFormatter = new Formatter\CliFormatter();
-        $this->jsonFormatter = new Formatter\JsonFormatter();
     }
 
     protected function configure(): void
@@ -159,7 +157,7 @@ final class SolveCommand extends Console\Command\Command
 
     private function solveProblem(Throwable $exception, Formatter\Formatter $formatter): ?string
     {
-        $solver = new ProblemSolving\Solver($this->solutionProvider, $formatter);
+        $solver = new ProblemSolving\Solver($this->configuration, $formatter, $this->solutionProvider);
 
         return $solver->solve($exception);
     }

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -133,7 +133,7 @@ final class Configuration
             $providerClass = self::DEFAULT_PROVIDER;
         }
 
-        return new $providerClass();
+        return $providerClass::create();
     }
 
     public function getPrompt(): ProblemSolving\Solution\Prompt\Prompt
@@ -147,7 +147,7 @@ final class Configuration
             $promptClass = self::DEFAULT_PROMPT;
         }
 
-        return new $promptClass();
+        return $promptClass::create();
     }
 
     /**

--- a/Classes/Exception/MissingSolutionProviderException.php
+++ b/Classes/Exception/MissingSolutionProviderException.php
@@ -21,29 +21,18 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Solver\Tests\Unit\Fixtures;
-
-use EliasHaeussler\Typo3Solver\ProblemSolving;
-use Throwable;
+namespace EliasHaeussler\Typo3Solver\Exception;
 
 /**
- * DummyPrompt
+ * MissingSolutionProviderException
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
- * @internal
  */
-final class DummyPrompt implements ProblemSolving\Solution\Prompt\Prompt
+final class MissingSolutionProviderException extends Exception
 {
-    public string $prompt = '';
-
-    public static function create(): static
+    public static function forDelegate(): self
     {
-        return new self();
-    }
-
-    public function generate(Throwable $exception): string
-    {
-        return $this->prompt;
+        return new self('No delegating solution provider given.', 1681199893);
     }
 }

--- a/Classes/Formatter/CliFormatter.php
+++ b/Classes/Formatter/CliFormatter.php
@@ -37,12 +37,11 @@ use function trim;
  */
 final class CliFormatter implements Formatter
 {
-    private readonly View\TemplateRenderer $renderer;
     private ?Console\Output\OutputInterface $output = null;
 
-    public function __construct()
-    {
-        $this->renderer = new View\TemplateRenderer();
+    public function __construct(
+        private readonly View\TemplateRenderer $renderer,
+    ) {
     }
 
     public function format(

--- a/Classes/Formatter/Message/ExceptionFormatter.php
+++ b/Classes/Formatter/Message/ExceptionFormatter.php
@@ -34,11 +34,9 @@ use Throwable;
  */
 final class ExceptionFormatter
 {
-    private readonly View\TemplateRenderer $renderer;
-
-    public function __construct()
-    {
-        $this->renderer = new View\TemplateRenderer();
+    public function __construct(
+        private readonly View\TemplateRenderer $renderer,
+    ) {
     }
 
     public function format(Throwable $exception): string

--- a/Classes/Formatter/WebFormatter.php
+++ b/Classes/Formatter/WebFormatter.php
@@ -43,13 +43,10 @@ final class WebFormatter implements Formatter
     private const SCRIPT_PATH = 'Resources/Public/JavaScript/main.js';
     private const STYLESHEET_PATH = 'Resources/Public/Css/main.css';
 
-    private readonly Cache\ExceptionsCache $exceptionsCache;
-    private readonly View\TemplateRenderer $renderer;
-
-    public function __construct()
-    {
-        $this->exceptionsCache = new Cache\ExceptionsCache();
-        $this->renderer = new View\TemplateRenderer();
+    public function __construct(
+        private readonly Cache\ExceptionsCache $exceptionsCache,
+        private readonly View\TemplateRenderer $renderer,
+    ) {
     }
 
     public function format(
@@ -81,6 +78,6 @@ final class WebFormatter implements Formatter
             return (string)@file_get_contents($filePath);
         }
 
-        return '';
+        return ''; // @codeCoverageIgnore
     }
 }

--- a/Classes/Formatter/WebStreamFormatter.php
+++ b/Classes/Formatter/WebStreamFormatter.php
@@ -41,11 +41,9 @@ use function json_encode;
  */
 final class WebStreamFormatter implements Formatter
 {
-    private readonly View\TemplateRenderer $renderer;
-
-    public function __construct()
-    {
-        $this->renderer = new View\TemplateRenderer();
+    public function __construct(
+        private readonly View\TemplateRenderer $renderer,
+    ) {
     }
 
     public function format(

--- a/Classes/Http/ClientFactory.php
+++ b/Classes/Http/ClientFactory.php
@@ -21,29 +21,39 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Solver\Tests\Unit\Fixtures;
+namespace EliasHaeussler\Typo3Solver\Http;
 
-use EliasHaeussler\Typo3Solver\ProblemSolving;
-use Throwable;
+use EliasHaeussler\Typo3Solver\Configuration;
+use EliasHaeussler\Typo3Solver\Exception;
+use OpenAI;
+use OpenAI\Client;
+
+use function trim;
 
 /**
- * DummyPrompt
+ * ClientFactory
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
- * @internal
  */
-final class DummyPrompt implements ProblemSolving\Solution\Prompt\Prompt
+final class ClientFactory
 {
-    public string $prompt = '';
-
-    public static function create(): static
-    {
-        return new self();
+    public function __construct(
+        private readonly Configuration\Configuration $configuration,
+    ) {
     }
 
-    public function generate(Throwable $exception): string
+    /**
+     * @throws Exception\ApiKeyMissingException
+     */
+    public function get(): Client
     {
-        return $this->prompt;
+        $apiKey = $this->configuration->getApiKey();
+
+        if ($apiKey === null || trim($apiKey) === '') {
+            throw Exception\ApiKeyMissingException::create();
+        }
+
+        return OpenAI::client($apiKey);
     }
 }

--- a/Classes/Middleware/SolutionMiddleware.php
+++ b/Classes/Middleware/SolutionMiddleware.php
@@ -49,6 +49,7 @@ final class SolutionMiddleware implements Server\MiddlewareInterface
         private readonly Configuration\Configuration $configuration,
         private readonly Cache\ExceptionsCache $exceptionsCache,
         private readonly Formatter\Message\ExceptionStreamFormatter $exceptionFormatter,
+        private readonly Formatter\WebStreamFormatter $webFormatter,
     ) {
     }
 
@@ -73,7 +74,7 @@ final class SolutionMiddleware implements Server\MiddlewareInterface
         }
 
         // Create solver
-        $solver = new ProblemSolving\Solver($this->configuration->getProvider(), new Formatter\WebStreamFormatter());
+        $solver = new ProblemSolving\Solver($this->configuration, $this->webFormatter);
 
         // Create event stream
         $eventStream = Http\EventStream::create($id);

--- a/Classes/ProblemSolving/Solution/Prompt/DefaultPrompt.php
+++ b/Classes/ProblemSolving/Solution/Prompt/DefaultPrompt.php
@@ -40,12 +40,16 @@ use function trim;
 final class DefaultPrompt implements Prompt
 {
     private readonly Core\Information\Typo3Version $typo3Version;
-    private readonly View\TemplateRenderer $renderer;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly View\TemplateRenderer $renderer,
+    ) {
         $this->typo3Version = new Core\Information\Typo3Version();
-        $this->renderer = new View\TemplateRenderer();
+    }
+
+    public static function create(): static
+    {
+        return new self(new View\TemplateRenderer());
     }
 
     public function generate(Throwable $exception): string

--- a/Classes/ProblemSolving/Solution/Prompt/Prompt.php
+++ b/Classes/ProblemSolving/Solution/Prompt/Prompt.php
@@ -33,5 +33,7 @@ use Throwable;
  */
 interface Prompt
 {
+    public static function create(): static;
+
     public function generate(Throwable $exception): string;
 }

--- a/Classes/ProblemSolving/Solution/Provider/CacheSolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/CacheSolutionProvider.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider;
 
 use EliasHaeussler\Typo3Solver\Cache;
+use EliasHaeussler\Typo3Solver\Exception;
 use EliasHaeussler\Typo3Solver\ProblemSolving;
 use Throwable;
 use Traversable;
@@ -40,6 +41,18 @@ final class CacheSolutionProvider implements StreamedSolutionProvider
         private readonly Cache\SolutionsCache $cache,
         private readonly SolutionProvider $provider,
     ) {
+    }
+
+    /**
+     * @throws Exception\MissingSolutionProviderException
+     */
+    public static function create(SolutionProvider $delegate = null): static
+    {
+        if ($delegate === null) {
+            throw Exception\MissingSolutionProviderException::forDelegate();
+        }
+
+        return new self(new Cache\SolutionsCache(), $delegate);
     }
 
     public function getSolution(ProblemSolving\Problem\Problem $problem): ProblemSolving\Solution\Solution

--- a/Classes/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProvider.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider;
 
 use EliasHaeussler\Typo3Solver\Cache;
+use EliasHaeussler\Typo3Solver\Exception;
 use EliasHaeussler\Typo3Solver\ProblemSolving;
 use OpenAI\Responses;
 use Throwable;
@@ -42,6 +43,18 @@ final class DelegatingCacheSolutionProvider implements SolutionProvider
         private readonly Cache\SolutionsCache $cache,
         private readonly SolutionProvider $delegate,
     ) {
+    }
+
+    /**
+     * @throws Exception\MissingSolutionProviderException
+     */
+    public static function create(SolutionProvider $delegate = null): static
+    {
+        if ($delegate === null) {
+            throw Exception\MissingSolutionProviderException::forDelegate();
+        }
+
+        return new self(new Cache\SolutionsCache(), $delegate);
     }
 
     public function getSolution(ProblemSolving\Problem\Problem $problem): ProblemSolving\Solution\Solution

--- a/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
@@ -25,8 +25,8 @@ namespace EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider;
 
 use EliasHaeussler\Typo3Solver\Configuration;
 use EliasHaeussler\Typo3Solver\Exception;
+use EliasHaeussler\Typo3Solver\Http;
 use EliasHaeussler\Typo3Solver\ProblemSolving;
-use OpenAI;
 use OpenAI\Client;
 use OpenAI\Responses;
 use Throwable;
@@ -36,14 +36,18 @@ use function in_array;
 
 final class OpenAISolutionProvider implements StreamedSolutionProvider
 {
-    private readonly Configuration\Configuration $configuration;
-    private readonly Client $client;
-
     public function __construct(
-        Client $client = null,
+        private readonly Configuration\Configuration $configuration,
+        private readonly Client $client,
     ) {
-        $this->configuration = new Configuration\Configuration();
-        $this->client = $client ?? OpenAI::client($this->configuration->getApiKey() ?? '');
+    }
+
+    public static function create(Client $client = null): static
+    {
+        $configuration = new Configuration\Configuration();
+        $client ??= (new Http\ClientFactory($configuration))->get();
+
+        return new self($configuration, $client);
     }
 
     /**

--- a/Classes/ProblemSolving/Solution/Provider/SolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/SolutionProvider.php
@@ -35,6 +35,8 @@ use Throwable;
  */
 interface SolutionProvider
 {
+    public static function create(): static;
+
     /**
      * @throws Exception\UnableToSolveException
      */

--- a/Classes/ProblemSolving/Solver.php
+++ b/Classes/ProblemSolving/Solver.php
@@ -39,14 +39,16 @@ use Traversable;
 final class Solver
 {
     private readonly Solution\Provider\CacheSolutionProvider $provider;
-    private readonly Configuration\Configuration $configuration;
 
     public function __construct(
-        Solution\Provider\SolutionProvider $solutionProvider,
+        private readonly Configuration\Configuration $configuration,
         private readonly Formatter\Formatter $formatter,
+        Solution\Provider\SolutionProvider $solutionProvider = null,
     ) {
-        $this->provider = new Solution\Provider\CacheSolutionProvider(new Cache\SolutionsCache(), $solutionProvider);
-        $this->configuration = new Configuration\Configuration();
+        $this->provider = new Solution\Provider\CacheSolutionProvider(
+            new Cache\SolutionsCache(),
+            $solutionProvider ?? $this->configuration->getProvider(),
+        );
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,6 +6,13 @@ services:
 
   EliasHaeussler\Typo3Solver\:
     resource: '../Classes/*'
+    exclude:
+      - '../Classes/Error/*'
+      - '../Classes/Exception/*'
+      - '../Classes/Extension.php'
+      - '../Classes/Http/EventStream.php'
+      - '../Classes/ProblemSolving/Problem/Problem.php'
+      - '../Classes/ProblemSolving/Solution/Solution.php'
 
   EliasHaeussler\Typo3Solver\Command\CacheFlushCommand:
     tags:
@@ -26,3 +33,6 @@ services:
         command: 'solver:solve'
         description: 'Solve a specific problem'
         schedulable: false
+
+  OpenAI\Client:
+    factory: ['@EliasHaeussler\Typo3Solver\Http\ClientFactory', 'get']

--- a/README.md
+++ b/README.md
@@ -283,13 +283,24 @@ The used OpenAI component changed from text completion to chat completion.
 * Migrate the used model in your [extension configuration](#attributesmodel).
   The new default model is `gpt-3.5-turbo-0301`.
 
-#### Solution Stream
+#### Solution stream
 
 Solutions are now streamed to exception pages.
 
 * Migrate custom solution providers to implement
   [`ProblemSolving\Solution\Provider\StreamedSolutionProvider`][21].
 * Note the modified DOM structure for solutions on exception pages.
+
+#### Dependency injection
+
+Several classes are now ready for dependency injection.
+
+* Migrate custom classes to use dependency injection.
+* Implement new static factory method `create()` within custom solution
+  providers and prompts.
+* Make sure custom classes can be used without dependency injection as
+  well, since exception handling may happen on a very low level where DI
+  is not available (yet).
 
 ## 🧑‍💻 Contributing
 

--- a/Tests/Build/console-application.php
+++ b/Tests/Build/console-application.php
@@ -19,19 +19,21 @@
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\Typo3Solver\Cache;
-use EliasHaeussler\Typo3Solver\Command;
-use EliasHaeussler\Typo3Solver\Configuration;
+use EliasHaeussler\Typo3Solver as Src;
+use EliasHaeussler\Typo3Solver\Tests;
 use Symfony\Component\Console;
 
 $application = new Console\Application();
-$application->add(new Command\CacheFlushCommand(new Cache\SolutionsCache()));
-$application->add(new Command\ListModelsCommand());
+$application->add(new Src\Command\CacheFlushCommand(new Src\Cache\SolutionsCache()));
+$application->add(new Src\Command\ListModelsCommand(OpenAI::factory()->make()));
 $application->add(
-    new Command\SolveCommand(
-        new Configuration\Configuration(),
-        new Cache\ExceptionsCache(),
-        new Cache\SolutionsCache(),
+    new Src\Command\SolveCommand(
+        new Src\Configuration\Configuration(),
+        new Src\Cache\ExceptionsCache(),
+        new Src\Cache\SolutionsCache(),
+        new Src\Formatter\CliFormatter(new Src\View\TemplateRenderer()),
+        new Src\Formatter\JsonFormatter(),
+        Tests\Unit\Fixtures\DummySolutionProvider::create(),
     ),
 );
 

--- a/Tests/Hook/ExtensionConfigurationHook.php
+++ b/Tests/Hook/ExtensionConfigurationHook.php
@@ -21,39 +21,38 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Solver\Formatter\Message;
+namespace EliasHaeussler\Typo3Solver\Tests\Hook;
 
-use EliasHaeussler\Typo3Solver\View;
-use Throwable;
-
-use function json_encode;
+use EliasHaeussler\Typo3Solver as Src;
+use PHPUnit\Runner;
 
 /**
- * ExceptionStreamFormatter
+ * ExtensionConfigurationHook
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
-final class ExceptionStreamFormatter
+final class ExtensionConfigurationHook implements Runner\BeforeTestHook
 {
-    public function __construct(
-        private readonly View\TemplateRenderer $renderer,
-    ) {
-    }
-
-    public function format(Throwable $exception): string
+    public function executeBeforeTest(string $test): void
     {
-        $json = [
-            'data' => [
-                'message' => $exception->getMessage(),
-                'code' => $exception->getCode(),
+        /* @phpstan-ignore-next-line */
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Src\Extension::KEY] = [
+            'api' => [
+                'key' => 'foo',
             ],
-            'content' => $this->renderer->render('Message/Exception', [
-                'exception' => $exception,
-                'exceptionClass' => $exception::class,
-            ]),
+            'attributes' => [
+                'maxTokens' => '300',
+                'model' => 'gpt-3.5-turbo-0301',
+                'numberOfCompletions' => '1',
+                'temperature' => '0.5',
+            ],
+            'cache' => [
+                'lifetime' => '86400',
+            ],
+            'ignoredCodes' => '',
+            'prompt' => Src\ProblemSolving\Solution\Prompt\DefaultPrompt::class,
+            'provider' => Src\ProblemSolving\Solution\Provider\OpenAISolutionProvider::class,
         ];
-
-        return json_encode($json, JSON_THROW_ON_ERROR);
     }
 }

--- a/Tests/Unit/Command/ListModelsCommandTest.php
+++ b/Tests/Unit/Command/ListModelsCommandTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "solver".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Solver\Tests\Unit\Command;
+
+use EliasHaeussler\Typo3Solver as Src;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler;
+use GuzzleHttp\Psr7;
+use OpenAI;
+use Symfony\Component\Console;
+use TYPO3\TestingFramework;
+
+use function implode;
+use function json_encode;
+
+/**
+ * ListModelsCommandTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ListModelsCommandTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Handler\MockHandler $mockHandler;
+    private Console\Tester\CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        $this->mockHandler = new Handler\MockHandler();
+
+        $command = new Src\Command\ListModelsCommand(
+            OpenAI::factory()->withHttpClient(new Client(['handler' => $this->mockHandler]))->make(),
+        );
+
+        $this->commandTester = new Console\Tester\CommandTester($command);
+    }
+
+    /**
+     * @test
+     */
+    public function executeListsAllAvailableModels(): void
+    {
+        $defaults = [
+            'object' => 'object',
+            'created' => 123,
+            'owned_by' => 'owned_by',
+            'permission' => [
+                [
+                    'id' => 'id',
+                    'object' => 'object',
+                    'created' => 123,
+                    'allow_create_engine' => true,
+                    'allow_sampling' => true,
+                    'allow_logprobs' => true,
+                    'allow_search_indices' => true,
+                    'allow_view' => true,
+                    'allow_fine_tuning' => true,
+                    'organization' => 'organization',
+                    'group' => 'group',
+                    'is_blocking' => true,
+                ],
+            ],
+            'root' => 'root',
+            'parent' => 'parent',
+        ];
+
+        $response = new Psr7\Response(headers: ['Content-Type' => 'application/json']);
+        $response->getBody()->write(json_encode([
+            'object' => 'object',
+            'data' => [
+                [
+                    'id' => 'foo-1',
+                    ...$defaults,
+                ],
+                [
+                    'id' => 'foo-2',
+                    ...$defaults,
+                ],
+                [
+                    'id' => 'baz-2',
+                    ...$defaults,
+                ],
+                [
+                    'id' => 'baz-1',
+                    ...$defaults,
+                ],
+            ],
+        ], JSON_THROW_ON_ERROR));
+        $response->getBody()->rewind();
+
+        $this->mockHandler->append($response);
+
+        $this->commandTester->execute([]);
+
+        self::assertStringContainsString(
+            implode(PHP_EOL, [
+                ' * baz-1',
+                ' * baz-2',
+                ' * foo-1',
+                ' * foo-2',
+            ]),
+            $this->commandTester->getDisplay(),
+        );
+    }
+}

--- a/Tests/Unit/Command/SolveCommandTest.php
+++ b/Tests/Unit/Command/SolveCommandTest.php
@@ -51,13 +51,15 @@ final class SolveCommandTest extends TestingFramework\Core\Unit\UnitTestCase
 
         $this->exceptionsCache = new Src\Cache\ExceptionsCache();
         $this->solutionsCache = new Src\Cache\SolutionsCache();
-        $this->provider = new Tests\Unit\Fixtures\DummySolutionProvider();
-        $this->prompt = new Src\ProblemSolving\Solution\Prompt\DefaultPrompt();
+        $this->provider = Tests\Unit\Fixtures\DummySolutionProvider::create();
+        $this->prompt = Src\ProblemSolving\Solution\Prompt\DefaultPrompt::create();
 
         $command = new Src\Command\SolveCommand(
             new Src\Configuration\Configuration(),
             $this->exceptionsCache,
             $this->solutionsCache,
+            new Src\Formatter\CliFormatter(new Src\View\TemplateRenderer()),
+            new Src\Formatter\JsonFormatter(),
             $this->provider,
         );
 

--- a/Tests/Unit/Exception/MissingSolutionProviderExceptionTest.php
+++ b/Tests/Unit/Exception/MissingSolutionProviderExceptionTest.php
@@ -21,29 +21,27 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Solver\Tests\Unit\Fixtures;
+namespace EliasHaeussler\Typo3Solver\Tests\Unit\Exception;
 
-use EliasHaeussler\Typo3Solver\ProblemSolving;
-use Throwable;
+use EliasHaeussler\Typo3Solver as Src;
+use TYPO3\TestingFramework;
 
 /**
- * DummyPrompt
+ * MissingSolutionProviderExceptionTest
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
- * @internal
  */
-final class DummyPrompt implements ProblemSolving\Solution\Prompt\Prompt
+final class MissingSolutionProviderExceptionTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    public string $prompt = '';
-
-    public static function create(): static
+    /**
+     * @test
+     */
+    public function forDelegateReturnsExceptionForDelegate(): void
     {
-        return new self();
-    }
+        $actual = Src\Exception\MissingSolutionProviderException::forDelegate();
 
-    public function generate(Throwable $exception): string
-    {
-        return $this->prompt;
+        self::assertSame('No delegating solution provider given.', $actual->getMessage());
+        self::assertSame(1681199893, $actual->getCode());
     }
 }

--- a/Tests/Unit/Fixtures/DummySolutionProvider.php
+++ b/Tests/Unit/Fixtures/DummySolutionProvider.php
@@ -39,6 +39,11 @@ final class DummySolutionProvider implements ProblemSolving\Solution\Provider\So
     public bool $shouldBeUsed = true;
     public bool $isCacheable = true;
 
+    public static function create(): static
+    {
+        return new self();
+    }
+
     public function getSolution(ProblemSolving\Problem\Problem $problem): ProblemSolving\Solution\Solution
     {
         return $this->solution ?? new ProblemSolving\Solution\Solution([], 'foo', 'baz');

--- a/Tests/Unit/Fixtures/DummyStreamedSolutionProvider.php
+++ b/Tests/Unit/Fixtures/DummyStreamedSolutionProvider.php
@@ -44,6 +44,11 @@ final class DummyStreamedSolutionProvider implements ProblemSolving\Solution\Pro
      */
     public array $solutionStream = [];
 
+    public static function create(): static
+    {
+        return new self();
+    }
+
     public function getSolution(ProblemSolving\Problem\Problem $problem): ProblemSolving\Solution\Solution
     {
         return $this->solution ?? new ProblemSolving\Solution\Solution([], 'foo', 'baz');

--- a/Tests/Unit/Formatter/CliFormatterTest.php
+++ b/Tests/Unit/Formatter/CliFormatterTest.php
@@ -44,7 +44,7 @@ final class CliFormatterTest extends TestingFramework\Core\Unit\UnitTestCase
     {
         parent::setUp();
 
-        $this->subject = new Src\Formatter\CliFormatter();
+        $this->subject = new Src\Formatter\CliFormatter(new Src\View\TemplateRenderer());
     }
 
     /**

--- a/Tests/Unit/Formatter/Message/ExceptionFormatterTest.php
+++ b/Tests/Unit/Formatter/Message/ExceptionFormatterTest.php
@@ -44,7 +44,7 @@ final class ExceptionFormatterTest extends TestingFramework\Core\Unit\UnitTestCa
     {
         parent::setUp();
 
-        $this->subject = new Src\Formatter\Message\ExceptionFormatter();
+        $this->subject = new Src\Formatter\Message\ExceptionFormatter(new Src\View\TemplateRenderer());
     }
 
     /**

--- a/Tests/Unit/Formatter/Message/ExceptionStreamFormatterTest.php
+++ b/Tests/Unit/Formatter/Message/ExceptionStreamFormatterTest.php
@@ -44,7 +44,7 @@ final class ExceptionStreamFormatterTest extends TestingFramework\Core\Unit\Unit
     {
         parent::setUp();
 
-        $this->subject = new Src\Formatter\Message\ExceptionStreamFormatter();
+        $this->subject = new Src\Formatter\Message\ExceptionStreamFormatter(new Src\View\TemplateRenderer());
     }
 
     /**

--- a/Tests/Unit/Formatter/WebFormatterTest.php
+++ b/Tests/Unit/Formatter/WebFormatterTest.php
@@ -41,15 +41,15 @@ final class WebFormatterTest extends TestingFramework\Core\Unit\UnitTestCase
 {
     use Tests\DOMDocumentTrait;
 
-    private Src\Formatter\WebFormatter $subject;
     private Src\Cache\ExceptionsCache $exceptionsCache;
+    private Src\Formatter\WebFormatter $subject;
 
     protected function setUp(): void
     {
         parent::setUp();
 
-        $this->subject = new Src\Formatter\WebFormatter();
         $this->exceptionsCache = new Src\Cache\ExceptionsCache();
+        $this->subject = new Src\Formatter\WebFormatter($this->exceptionsCache, new Src\View\TemplateRenderer());
     }
 
     /**

--- a/Tests/Unit/Formatter/WebStreamFormatterTest.php
+++ b/Tests/Unit/Formatter/WebStreamFormatterTest.php
@@ -45,7 +45,7 @@ final class WebStreamFormatterTest extends TestingFramework\Core\Unit\UnitTestCa
     {
         parent::setUp();
 
-        $this->subject = new Src\Formatter\WebStreamFormatter();
+        $this->subject = new Src\Formatter\WebStreamFormatter(new Src\View\TemplateRenderer());
     }
 
     /**

--- a/Tests/Unit/Http/ClientFactoryTest.php
+++ b/Tests/Unit/Http/ClientFactoryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "solver".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\Typo3Solver\Tests\Unit\Http;
+
+use EliasHaeussler\Typo3Solver as Src;
+use TYPO3\TestingFramework;
+
+/**
+ * ClientFactoryTest
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-2.0-or-later
+ */
+final class ClientFactoryTest extends TestingFramework\Core\Unit\UnitTestCase
+{
+    private Src\Tests\Unit\Fixtures\DummyConfigurationProvider $provider;
+    private Src\Http\ClientFactory $subject;
+
+    protected function setUp(): void
+    {
+        $this->provider = new Src\Tests\Unit\Fixtures\DummyConfigurationProvider();
+        $this->subject = new Src\Http\ClientFactory(new Src\Configuration\Configuration($this->provider));
+    }
+
+    /**
+     * @test
+     */
+    public function getThrowsExceptionIfApiKeyIsNotConfigured(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\ApiKeyMissingException::create(),
+        );
+
+        $this->subject->get();
+    }
+
+    /**
+     * @test
+     */
+    public function getReturnsOpenAIClient(): void
+    {
+        $exception = null;
+
+        $this->provider->configuration = [
+            'api/key' => 'foo',
+        ];
+
+        try {
+            $this->subject->get();
+        } catch (Src\Exception\ApiKeyMissingException $exception) {
+            // Intended fallthrough.
+        }
+
+        self::assertNull($exception);
+    }
+}

--- a/Tests/Unit/ProblemSolving/Solution/Prompt/DefaultPromptTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Prompt/DefaultPromptTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Prompt;
+namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Solution\Prompt;
 
 use EliasHaeussler\Typo3Solver as Src;
 use Exception;
@@ -42,7 +42,7 @@ final class DefaultPromptTest extends TestingFramework\Core\Unit\UnitTestCase
     {
         parent::setUp();
 
-        $this->subject = new Src\ProblemSolving\Solution\Prompt\DefaultPrompt();
+        $this->subject = new Src\ProblemSolving\Solution\Prompt\DefaultPrompt(new Src\View\TemplateRenderer());
     }
 
     /**

--- a/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
@@ -56,6 +56,29 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
     /**
      * @test
      */
+    public function createThrowsExceptionIfDelegatingProviderIsNotGiven(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\MissingSolutionProviderException::forDelegate(),
+        );
+
+        Src\ProblemSolving\Solution\Provider\CacheSolutionProvider::create();
+    }
+
+    /**
+     * @test
+     */
+    public function createReturnsInitializedProviderWithGivenDelegate(): void
+    {
+        self::assertEquals(
+            $this->subject,
+            Src\ProblemSolving\Solution\Provider\CacheSolutionProvider::create($this->provider),
+        );
+    }
+
+    /**
+     * @test
+     */
     public function getSolutionReturnsSolutionFromCache(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);

--- a/Tests/Unit/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProviderTest.php
@@ -55,6 +55,29 @@ final class DelegatingCacheSolutionProviderTest extends TestingFramework\Core\Un
     /**
      * @test
      */
+    public function createThrowsExceptionIfDelegatingProviderIsNotGiven(): void
+    {
+        $this->expectExceptionObject(
+            Src\Exception\MissingSolutionProviderException::forDelegate(),
+        );
+
+        Src\ProblemSolving\Solution\Provider\DelegatingCacheSolutionProvider::create();
+    }
+
+    /**
+     * @test
+     */
+    public function createReturnsInitializedProviderWithGivenDelegate(): void
+    {
+        self::assertEquals(
+            $this->subject,
+            Src\ProblemSolving\Solution\Provider\DelegatingCacheSolutionProvider::create($this->provider),
+        );
+    }
+
+    /**
+     * @test
+     */
     public function getSolutionReturnsSolutionFromCache(): void
     {
         $problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->provider);

--- a/Tests/Unit/ProblemSolving/Solution/Provider/OpenAISolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/OpenAISolutionProviderTest.php
@@ -44,6 +44,7 @@ use function json_encode;
 final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTestCase
 {
     private Handler\MockHandler $mockHandler;
+    private OpenAI\Client $client;
     private Src\ProblemSolving\Solution\Provider\OpenAISolutionProvider $subject;
     private Src\ProblemSolving\Problem\Problem $problem;
 
@@ -52,18 +53,27 @@ final class OpenAISolutionProviderTest extends TestingFramework\Core\Unit\UnitTe
         parent::setUp();
 
         $this->mockHandler = new Handler\MockHandler();
-
-        $client = OpenAI::factory()
-            ->withHttpClient(new Client(['handler' => $this->mockHandler]))
-            ->make()
-        ;
-
-        $this->subject = new Src\ProblemSolving\Solution\Provider\OpenAISolutionProvider($client);
+        $this->client = OpenAI::factory()->withHttpClient(new Client(['handler' => $this->mockHandler]))->make();
+        $this->subject = new Src\ProblemSolving\Solution\Provider\OpenAISolutionProvider(
+            new Src\Configuration\Configuration(),
+            $this->client,
+        );
         $this->problem = Tests\Unit\DataProvider\ProblemDataProvider::get(solutionProvider: $this->subject);
 
         // Configure API key
         /* @phpstan-ignore-next-line */
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Src\Extension::KEY]['api']['key'] = 'foo';
+    }
+
+    /**
+     * @test
+     */
+    public function createReturnsInitializedProvider(): void
+    {
+        self::assertEquals(
+            $this->subject,
+            Src\ProblemSolving\Solution\Provider\OpenAISolutionProvider::create($this->client),
+        );
     }
 
     /**

--- a/Tests/Unit/ProblemSolving/SolverTest.php
+++ b/Tests/Unit/ProblemSolving/SolverTest.php
@@ -47,7 +47,11 @@ final class SolverTest extends TestingFramework\Core\Unit\UnitTestCase
         parent::setUp();
 
         $this->provider = new Tests\Unit\Fixtures\DummyStreamedSolutionProvider();
-        $this->subject = new Src\ProblemSolving\Solver($this->provider, new Src\Formatter\JsonFormatter());
+        $this->subject = new Src\ProblemSolving\Solver(
+            new Src\Configuration\Configuration(),
+            new Src\Formatter\JsonFormatter(),
+            $this->provider,
+        );
 
         (new Src\Cache\SolutionsCache())->flush();
     }

--- a/phpunit.unit.coverage.xml
+++ b/phpunit.unit.coverage.xml
@@ -8,6 +8,9 @@
     <php>
         <env name="COLUMNS" value="300" />
     </php>
+    <extensions>
+        <extension class="EliasHaeussler\Typo3Solver\Tests\Hook\ExtensionConfigurationHook" />
+    </extensions>
     <coverage>
         <include>
             <directory suffix=".php">Classes</directory>

--- a/phpunit.unit.xml
+++ b/phpunit.unit.xml
@@ -8,6 +8,9 @@
     <php>
         <env name="COLUMNS" value="300" />
     </php>
+    <extensions>
+        <extension class="EliasHaeussler\Typo3Solver\Tests\Hook\ExtensionConfigurationHook" />
+    </extensions>
     <coverage>
         <include>
             <directory suffix=".php">Classes</directory>


### PR DESCRIPTION
This PR rewrites a bunch of classes to allow constructor injection using the service container. Since several classes are also used on a very low level, some of them are still instantiated by without the service container. In addition, solution providers and prompts are now forced to implement a `create()` factory method.