### PR TITLE
[TASK] Run `composer normalize` for fixture extensions as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,8 @@
 		],
 		"fix:composer": [
 			"@composer normalize",
-			"@composer normalize Resources/Private/Libs/Build/composer.json"
+			"@composer normalize Resources/Private/Libs/Build/composer.json",
+			"@composer normalize Tests/Functional/Fixtures/Extensions/middleware_bridge/composer.json"
 		],
 		"fix:editorconfig": "@lint:editorconfig --fix",
 		"fix:php": "php-cs-fixer fix",


### PR DESCRIPTION
This PR extends the `fix:composer` and `lint:composer` scripts to run `composer normalize` for fixture extensions as well.