### PR TITLE
[BUGFIX] Avoid PHPUnit 10 for the time being

### DIFF
--- a/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/Tests/Unit/Configuration/ConfigurationTest.php
@@ -243,9 +243,6 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
      */
     public function getProviderReturnsDefaultProviderIfNoProviderIsConfigured(): void
     {
-        /** @phpstan-ignore-next-line  */
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solver']['api']['key'] = 'foo';
-
         self::assertInstanceOf(
             Src\ProblemSolving\Solution\Provider\OpenAISolutionProvider::class,
             $this->subject->getProvider(),
@@ -257,9 +254,6 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
      */
     public function getProviderReturnsDefaultProviderIfConfiguredProviderIsInvalid(): void
     {
-        /** @phpstan-ignore-next-line  */
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['solver']['api']['key'] = 'foo';
-
         $this->configurationProvider->configuration = [
             'provider' => 'foo',
         ];

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan-symfony": "^1.2",
 		"phpunit/phpcov": "^8.2 || ^9.0",
+		"phpunit/phpunit": "^9.6",
 		"saschaegerer/phpstan-typo3": "^1.8",
 		"symfony/dependency-injection": "^5.4 || ^6.0",
 		"typo3/coding-standards": "^0.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "38fcc09936f1a412007038fa336405de",
+    "content-hash": "fde8ee40fd8075309d7a457730882247",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
The `ExtensionConfigurationHook` already sets a very basic extension configuration. Thus, it should not be necessary to re-configure it in concrete test cases. On the other hand, this hook is not compatible with PHPUnit 10. That's why we avoid PHPUnit 10 for the time being and wait until there's a better (TYPO3 v11.5 compatible) solution for PHPUnit 10.