### PR TITLE
[BUGFIX] Ignore fixture extensions from Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,12 @@
 				"Tests/Functional/Fixtures/Extensions/middleware_bridge/composer.json"
 			],
 			"enabled": false
+		},
+		{
+			"matchDepNames": [
+				"eliashaeussler/typo3-solver-middleware-bridge"
+			],
+			"enabled": false
 		}
 	]
 }


### PR DESCRIPTION
Fixture extensions cannot be updated and should therefore be ignored from Renovate.