### PR TITLE
[BUGFIX] Avoid usage of `ReflectionProperty::setAccessible()`

### DIFF
--- a/Classes/Cache/Serializer/ExceptionSerializer.php
+++ b/Classes/Cache/Serializer/ExceptionSerializer.php
@@ -80,7 +80,6 @@ final class ExceptionSerializer
         foreach ($properties as $propertyName => $propertyValue) {
             if ($reflectionClass->hasProperty($propertyName)) {
                 $reflectionProperty = $reflectionClass->getProperty($propertyName);
-                $reflectionProperty->setAccessible(true);
                 $reflectionProperty->setValue($exception, $propertyValue);
             }
         }


### PR DESCRIPTION
Calling `ReflectionProperty::setAccessible()` has no effect since PHP 8.1.0. Thus, it can be safely removed.