### PR TITLE
[BUGFIX] Avoid requiring test fixture extensions

### DIFF
--- a/Tests/Functional/Middleware/PingMiddlewareTest.php
+++ b/Tests/Functional/Middleware/PingMiddlewareTest.php
@@ -37,7 +37,7 @@ final class PingMiddlewareTest extends TestingFramework\Core\Functional\Function
     use Tests\InternalRequestTrait;
 
     protected array $testExtensionsToLoad = [
-        'middleware_bridge',
+        'typo3conf/ext/solver/Tests/Functional/Fixtures/Extensions/middleware_bridge',
     ];
 
     protected bool $initializeDatabase = false;

--- a/Tests/Functional/Middleware/SolutionMiddlewareTest.php
+++ b/Tests/Functional/Middleware/SolutionMiddlewareTest.php
@@ -37,7 +37,7 @@ final class SolutionMiddlewareTest extends TestingFramework\Core\Functional\Func
     use Tests\InternalRequestTrait;
 
     protected array $testExtensionsToLoad = [
-        'middleware_bridge',
+        'typo3conf/ext/solver/Tests/Functional/Fixtures/Extensions/middleware_bridge',
     ];
 
     protected bool $initializeDatabase = false;

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,6 @@
 		"armin/editorconfig-cli": "^1.5",
 		"eliashaeussler/phpstan-config": "^1.0",
 		"eliashaeussler/rector-config": "^1.1.1",
-		"eliashaeussler/typo3-solver-middleware-bridge": "^1.0",
 		"ergebnis/composer-normalize": "^2.29",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan-symfony": "^1.2",
@@ -47,14 +46,8 @@
 		"saschaegerer/phpstan-typo3": "^1.8",
 		"symfony/dependency-injection": "^5.4 || ^6.0",
 		"typo3/coding-standards": "^0.7.1",
-		"typo3/testing-framework": "^7.0.1 || ^8.0"
+		"typo3/testing-framework": "^7.0.2 || ^8.0.1"
 	},
-	"repositories": [
-		{
-			"type": "path",
-			"url": "Tests/Functional/Fixtures/Extensions/*"
-		}
-	],
 	"autoload": {
 		"psr-4": {
 			"EliasHaeussler\\Typo3Solver\\": "Classes/"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fde8ee40fd8075309d7a457730882247",
+    "content-hash": "644b5623520ea701c5046ee227bcf603",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5604,27 +5604,6 @@
                 "source": "https://github.com/eliashaeussler/rector-config/tree/1.4.0"
             },
             "time": "2023-05-05T14:58:43+00:00"
-        },
-        {
-            "name": "eliashaeussler/typo3-solver-middleware-bridge",
-            "version": "1.0.0",
-            "dist": {
-                "type": "path",
-                "url": "Tests/Functional/Fixtures/Extensions/middleware_bridge",
-                "reference": "8e26cd2fcf6852b5f7446e3667565cac52b77ae3"
-            },
-            "require": {
-                "typo3/cms-core": "*@dev"
-            },
-            "type": "typo3-cms-extension",
-            "extra": {
-                "typo3/cms": {
-                    "extension-key": "middleware_bridge"
-                }
-            },
-            "transport-options": {
-                "relative": true
-            }
         },
         {
             "name": "ergebnis/composer-normalize",

--- a/renovate.json
+++ b/renovate.json
@@ -23,12 +23,6 @@
 				"Tests/Functional/Fixtures/Extensions/middleware_bridge/composer.json"
 			],
 			"enabled": false
-		},
-		{
-			"matchDepNames": [
-				"eliashaeussler/typo3-solver-middleware-bridge"
-			],
-			"enabled": false
 		}
 	]
 }


### PR DESCRIPTION
This PR reverts an intermediate solution introduced to circumvent issues with TYPO3 Testing Framework v7/v8. Since those issues are now resolved, the fixture extensions must no longer be part of the requirements in composer.json.