### PR TITLE
[BUGFIX] Respect cache lifetime when getting cached solutions

### DIFF
--- a/Classes/Cache/SolutionsCache.php
+++ b/Classes/Cache/SolutionsCache.php
@@ -60,6 +60,11 @@ final class SolutionsCache
 
     public function get(ProblemSolving\Problem\Problem $problem): ?ProblemSolving\Solution\Solution
     {
+        // Early return if cache is disabled
+        if (!$problem->getSolutionProvider()->isCacheable() || !$this->configuration->isCacheEnabled()) {
+            return null;
+        }
+
         /** @phpstan-var array{solutions: array<string, SolutionArray>} $cacheData */
         $cacheData = require $this->cachePath;
         $entryIdentifier = $this->calculateCacheIdentifier($problem);
@@ -83,7 +88,7 @@ final class SolutionsCache
     public function set(ProblemSolving\Problem\Problem $problem, ProblemSolving\Solution\Solution $solution): void
     {
         // Early return if cache is disabled
-        if (!$problem->getSolutionProvider()->isCacheable() || $this->configuration->getCacheLifetime() === 0) {
+        if (!$problem->getSolutionProvider()->isCacheable() || !$this->configuration->isCacheEnabled()) {
             return;
         }
 

--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -122,6 +122,11 @@ final class Configuration
         return (int)$cacheLifetime;
     }
 
+    public function isCacheEnabled(): bool
+    {
+        return $this->getCacheLifetime() > 0;
+    }
+
     public function getProvider(): ProblemSolving\Solution\Provider\SolutionProvider
     {
         $providerClass = $this->provider->get('provider', self::DEFAULT_PROVIDER);

--- a/Documentation/DeveloperCorner/ConfigurationAPI.rst
+++ b/Documentation/DeveloperCorner/ConfigurationAPI.rst
@@ -52,6 +52,14 @@ an appropriate class method.
 
         :returntype: int
 
+    ..  php:method:: isCacheEnabled()
+
+        Check whether solution caching is currently enabled. The cache is
+        enabled if the configured :ref:`cache lifetime <extconf-cache-lifetime>`
+        is greater than :php:`0`.
+
+        :returntype: bool
+
     ..  php:method:: getProvider()
 
         Get the configured :ref:`solution provider <extconf-provider>`.

--- a/Tests/Unit/Cache/SolutionsCacheTest.php
+++ b/Tests/Unit/Cache/SolutionsCacheTest.php
@@ -71,6 +71,32 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
     /**
      * @test
      */
+    public function getReturnsNullIfSolutionProviderIsNotCacheable(): void
+    {
+        $solutionProvider = $this->problem->getSolutionProvider();
+
+        self::assertInstanceOf(Src\Tests\Unit\Fixtures\DummySolutionProvider::class, $solutionProvider);
+
+        $solutionProvider->isCacheable = false;
+
+        self::assertNull($this->subject->get($this->problem));
+    }
+
+    /**
+     * @test
+     */
+    public function getReturnsNullIfCacheIsDisabled(): void
+    {
+        // Disable cache
+        /* @phpstan-ignore-next-line */
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Src\Extension::KEY]['cache']['lifetime'] = 0;
+
+        self::assertNull($this->subject->get($this->problem));
+    }
+
+    /**
+     * @test
+     */
     public function getReturnsNullOnEmptyCache(): void
     {
         $this->subject->flush();
@@ -124,11 +150,14 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
      */
     public function setDoesNothingIfSolutionProviderIsNotCacheable(): void
     {
-        // Disable cache
-        /* @phpstan-ignore-next-line */
-        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Src\Extension::KEY]['cache']['lifetime'] = 0;
-
         $this->subject->flush();
+
+        $solutionProvider = $this->problem->getSolutionProvider();
+
+        self::assertInstanceOf(Src\Tests\Unit\Fixtures\DummySolutionProvider::class, $solutionProvider);
+
+        $solutionProvider->isCacheable = false;
+
         $this->subject->set($this->problem, $this->solution);
 
         self::assertNull($this->subject->get($this->problem));
@@ -139,14 +168,11 @@ final class SolutionsCacheTest extends TestingFramework\Core\Unit\UnitTestCase
      */
     public function setDoesNothingIfCacheIsDisabled(): void
     {
+        // Disable cache
+        /* @phpstan-ignore-next-line */
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'][Src\Extension::KEY]['cache']['lifetime'] = 0;
+
         $this->subject->flush();
-
-        $solutionProvider = $this->problem->getSolutionProvider();
-
-        self::assertInstanceOf(Src\Tests\Unit\Fixtures\DummySolutionProvider::class, $solutionProvider);
-
-        $solutionProvider->isCacheable = false;
-
         $this->subject->set($this->problem, $this->solution);
 
         self::assertNull($this->subject->get($this->problem));

--- a/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/Tests/Unit/Configuration/ConfigurationTest.php
@@ -241,6 +241,30 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
     /**
      * @test
      */
+    public function isCacheEnabledReturnsTrueIfCacheLifetimeIsGreaterThanZero(): void
+    {
+        $this->configurationProvider->configuration = [
+            'cache/lifetime' => 3600,
+        ];
+
+        self::assertTrue($this->subject->isCacheEnabled());
+    }
+
+    /**
+     * @test
+     */
+    public function isCacheEnabledReturnsFalseIfCacheLifetimeIsZero(): void
+    {
+        $this->configurationProvider->configuration = [
+            'cache/lifetime' => 0,
+        ];
+
+        self::assertFalse($this->subject->isCacheEnabled());
+    }
+
+    /**
+     * @test
+     */
     public function getProviderReturnsDefaultProviderIfNoProviderIsConfigured(): void
     {
         self::assertInstanceOf(


### PR DESCRIPTION
When calling `SolutionsCache::get()`, the configured cache lifetime is now properly respected. If caching is disabled by setting cache lifetime to `0` seconds, `SolutionsCache::get()` will always return `null`. For this, a new method `Configuration::isCacheEnabled()` was added.