### PR TITLE
[TASK] Require typo3fluid/fluid ^2.9

### DIFF
--- a/Classes/View/TemplateRenderer.php
+++ b/Classes/View/TemplateRenderer.php
@@ -59,9 +59,6 @@ final class TemplateRenderer
         $rootPath = dirname(__DIR__, 2) . '/Resources/Private';
         $renderingContext = new Fluid\Core\Rendering\RenderingContext();
 
-        // Can be removed once https://github.com/TYPO3/Fluid/issues/694 is resolved
-        $renderingContext->setControllerName('');
-
         $templatePaths = $renderingContext->getTemplatePaths();
         $templatePaths->setTemplateRootPaths([$rootPath . '/Templates']);
         $templatePaths->setPartialRootPaths([$rootPath . '/Partials']);

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"symfony/filesystem": "^5.4 || ^6.0",
 		"symfony/routing": "^5.4 || ^6.0",
 		"typo3/cms-core": "^11.5 || ^12.4",
-		"typo3fluid/fluid": "^2.7"
+		"typo3fluid/fluid": "^2.9"
 	},
 	"require-dev": {
 		"ext-dom": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08c03e2ad10c32e0a6820be16ebf7247",
+    "content-hash": "2805d8b03f30c362860b32a68cb43084",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -5281,16 +5281,16 @@
         },
         {
             "name": "typo3fluid/fluid",
-            "version": "2.8.0",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/Fluid.git",
-                "reference": "ac1aaa6548ddca663c11f165fe4e2c2ef51c3e38"
+                "reference": "203c14fab96482ece91cd311efe17bc2bef7efe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/ac1aaa6548ddca663c11f165fe4e2c2ef51c3e38",
-                "reference": "ac1aaa6548ddca663c11f165fe4e2c2ef51c3e38",
+                "url": "https://api.github.com/repos/TYPO3/Fluid/zipball/203c14fab96482ece91cd311efe17bc2bef7efe8",
+                "reference": "203c14fab96482ece91cd311efe17bc2bef7efe8",
                 "shasum": ""
             },
             "require": {
@@ -5327,7 +5327,7 @@
                 "issues": "https://github.com/TYPO3/Fluid/issues",
                 "source": "https://github.com/TYPO3/Fluid"
             },
-            "time": "2023-05-04T21:36:43+00:00"
+            "time": "2023-06-07T10:06:26+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
Since TYPO3/Fluid#694 is resolved and released as `2.9.0`, the temporary fix introduced with #102 is reverted and the minimum version of typo3fluid/fluid is raised.