### PR TITLE
[BUGFIX] Avoid duplicate workflow runs on renovate PRs

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -1,12 +1,13 @@
 name: Frontend assets
 on:
-  pull_request:
+  push:
+    branches:
+      - 'renovate/**'
     paths:
       - 'Resources/Private/Frontend/**'
 
 jobs:
   rebuild:
-    if: ${{ github.actor == 'renovate[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -3,11 +3,8 @@ on:
   push:
     branches:
       - main
-      - 'renovate/**'
   pull_request:
-    branches:
-      - '**'
-      - '!renovate/**'
+  workflow_call:
 
 jobs:
   cgl:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,25 @@
+name: Renovate
+on:
+  push:
+    branches:
+      - 'renovate/**'
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      pr-exists: ${{ steps.check.outputs.pr-exists }}
+    steps:
+      - name: Check if PR exists
+        id: check
+        uses: eliashaeussler/.github/actions/github/check-pr@1.0.0
+
+  trigger-cgl:
+    needs: check-pr
+    if: '!needs.check-pr.outputs.pr-exists'
+    uses: ./.github/workflows/cgl.yaml
+
+  trigger-tests:
+    needs: check-pr
+    if: '!needs.check-pr.outputs.pr-exists'
+    uses: ./.github/workflows/tests.yaml

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,11 +3,8 @@ on:
   push:
     branches:
       - main
-      - 'renovate/**'
   pull_request:
-    branches:
-      - '**'
-      - '!renovate/**'
+  workflow_call:
 
 jobs:
   tests:


### PR DESCRIPTION
This PR adds a new `Renovate` workflow. For each push into a `renovate/*` branch, the workflow checks if an appropriate PR is open. If not, the `CGL` and `Tests` workflows are triggered. This avoids duplicate workflows for both `push` and `pull_request` event on `renovate/*` branches.