### PR TITLE
[BUGFIX] Exclude frontend sources from packaging

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.ddev                              export-ignore
 /.github                            export-ignore
 /Documentation                      export-ignore
+/Resources/Private/Frontend         export-ignore
 /Resources/Private/Libs             export-ignore
 /Tests                              export-ignore
 /.editorconfig                      export-ignore

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -31,6 +31,7 @@ return [
         'build',
         'documentation',
         'public',
+        'resources\\/private\\/frontend',
         'resources\\/private\\/libs\\/build',
         'tailor-version-upload',
         'tests',


### PR DESCRIPTION
This PR adds the `Resources/Private/Frontend` to packaging excludes since frontend sources must not be present in dist archives.