### PR TITLE
[BUGFIX] Avoid timing issues in Unit tests by asserting with delta

### DIFF
--- a/Classes/Cache/Serializer/SolutionSerializer.php
+++ b/Classes/Cache/Serializer/SolutionSerializer.php
@@ -56,10 +56,12 @@ final class SolutionSerializer
      */
     public function serialize(ProblemSolving\Solution\Solution $solution): array
     {
+        $now = time();
+
         return [
             'solution' => $solution->toArray(),
-            'createdAt' => time(),
-            'validUntil' => time() + $this->configuration->getCacheLifetime(),
+            'createdAt' => $now,
+            'validUntil' => $now + $this->configuration->getCacheLifetime(),
         ];
     }
 

--- a/Tests/Unit/Cache/Serializer/SolutionSerializerTest.php
+++ b/Tests/Unit/Cache/Serializer/SolutionSerializerTest.php
@@ -54,11 +54,14 @@ final class SolutionSerializerTest extends TestingFramework\Core\Unit\UnitTestCa
     {
         $solution = Src\Tests\Unit\DataProvider\SolutionDataProvider::get();
 
+        $createTime = time();
+        $expiryTime = $createTime + $this->configuration->getCacheLifetime();
+
         $actual = $this->subject->serialize($solution);
 
         self::assertSame($solution->toArray(), $actual['solution']);
-        self::assertLessThanOrEqual(time(), $actual['createdAt']);
-        self::assertGreaterThanOrEqual(time() + $this->configuration->getCacheLifetime(), $actual['validUntil']);
+        self::assertEqualsWithDelta($createTime, $actual['createdAt'], 2.0);
+        self::assertEqualsWithDelta($expiryTime, $actual['validUntil'], 2.0);
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
This PR changes simple `assertEquals()` assertions to `assertEqualsWithDelta()` in order to avoid timing issues in tests.