### PR TITLE
[TASK] Migrate unmaintained babel plugin

### DIFF
--- a/Resources/Private/Frontend/.babelrc
+++ b/Resources/Private/Frontend/.babelrc
@@ -4,7 +4,7 @@
         "@babel/preset-typescript"
     ],
     "plugins": [
-        "@babel/plugin-proposal-class-properties",
+        "@babel/plugin-transform-class-properties",
         "@babel/plugin-transform-reserved-words",
         "@babel/plugin-transform-runtime"
     ]

--- a/Resources/Private/Frontend/package-lock.json
+++ b/Resources/Private/Frontend/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@babel/core": "^7.21.4",
-				"@babel/plugin-proposal-class-properties": "^7.18.6",
+				"@babel/plugin-transform-class-properties": "^7.24.7",
 				"@babel/plugin-transform-reserved-words": "^7.18.6",
 				"@babel/plugin-transform-runtime": "^7.21.4",
 				"@babel/preset-env": "^7.21.4",
@@ -499,23 +499,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/plugin-proposal-class-properties": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
-			"integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
-			"deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.18.6",
-				"@babel/helper-plugin-utils": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@babel/plugin-proposal-private-property-in-object": {

--- a/Resources/Private/Frontend/package.json
+++ b/Resources/Private/Frontend/package.json
@@ -20,7 +20,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "^7.21.4",
-		"@babel/plugin-proposal-class-properties": "^7.18.6",
+		"@babel/plugin-transform-class-properties": "^7.24.7",
 		"@babel/plugin-transform-reserved-words": "^7.18.6",
 		"@babel/plugin-transform-runtime": "^7.21.4",
 		"@babel/preset-env": "^7.21.4",


### PR DESCRIPTION
This PR migrates the deprecated plugin `@babel/plugin-proposal-class-properties` to `@babel/plugin-transform-class-properties`.