### PR TITLE
[!!!][TASK] Switch to `gpt-4o-mini` as default OpenAI model

### DIFF
--- a/Classes/Configuration/Configuration.php
+++ b/Classes/Configuration/Configuration.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Core;
  */
 final class Configuration
 {
-    private const DEFAULT_MODEL = 'gpt-3.5-turbo-0301';
+    private const DEFAULT_MODEL = 'gpt-4o-mini';
     private const DEFAULT_TOKENS = 300;
     private const DEFAULT_TEMPERATURE = 0.5;
     private const DEFAULT_NUMBER_OF_COMPLETIONS = 1;

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -65,7 +65,7 @@ The extension currently provides the following configuration options:
 
 ..  confval:: attributes.model
     :type: string
-    :Default: `gpt-3.5-turbo-0301`
+    :Default: `gpt-4o-mini`
 
     `OpenAI model <https://platform.openai.com/docs/models>`__ to use (see
     :ref:`List available models <solver-list-models>` to show a list of available

--- a/Tests/Extension/ExtensionConfigurationExtension.php
+++ b/Tests/Extension/ExtensionConfigurationExtension.php
@@ -53,7 +53,7 @@ final class ExtensionConfigurationExtension implements Runner\Extension\Extensio
             ],
             'attributes' => [
                 'maxTokens' => '300',
-                'model' => 'gpt-3.5-turbo-0301',
+                'model' => 'gpt-4o-mini',
                 'numberOfCompletions' => '1',
                 'temperature' => '0.5',
             ],

--- a/Tests/Unit/Configuration/ConfigurationTest.php
+++ b/Tests/Unit/Configuration/ConfigurationTest.php
@@ -77,7 +77,7 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
     #[Framework\Attributes\Test]
     public function getModelReturnsDefaultModelIfNoModelIsConfigured(): void
     {
-        self::assertSame('gpt-3.5-turbo-0301', $this->subject->getModel());
+        self::assertSame('gpt-4o-mini', $this->subject->getModel());
     }
 
     #[Framework\Attributes\Test]
@@ -87,7 +87,7 @@ final class ConfigurationTest extends TestingFramework\Core\Unit\UnitTestCase
             'attributes/model' => '',
         ];
 
-        self::assertSame('gpt-3.5-turbo-0301', $this->subject->getModel());
+        self::assertSame('gpt-4o-mini', $this->subject->getModel());
     }
 
     #[Framework\Attributes\Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -11,7 +11,7 @@ ignoredCodes =
 api.key =
 
 # cat=attributes//10; type=string; label=OpenAI model:You can list all available models by running the `solver:list-models` command
-attributes.model = gpt-3.5-turbo-0301
+attributes.model = gpt-4o-mini
 
 # cat=attributes//20; type=int+; label=Maximum number of tokens to use per request
 attributes.maxTokens = 300


### PR DESCRIPTION
This should only affect new installations.