### PR TITLE
[BUGFIX] List only supported models in `solver:list-models` command

### DIFF
--- a/Classes/Command/ListModelsCommand.php
+++ b/Classes/Command/ListModelsCommand.php
@@ -65,7 +65,7 @@ final class ListModelsCommand extends Console\Command\Command
             $io->title('Available GPT models');
 
             // Filter by GPT models
-            $modelListResponse = \array_filter($modelListResponse, $this->isGPTModel(...));
+            $modelListResponse = \array_filter($modelListResponse, $this->isSupportedModel(...));
         }
 
         // Map responses to model IDs
@@ -86,9 +86,18 @@ final class ListModelsCommand extends Console\Command\Command
         return self::SUCCESS;
     }
 
-    private function isGPTModel(Responses\Models\RetrieveResponse $response): bool
+    /**
+     * @see https://platform.openai.com/docs/models#model-endpoint-compatibility
+     */
+    private function isSupportedModel(Responses\Models\RetrieveResponse $response): bool
     {
-        return \str_starts_with(\strtolower($response->id), 'gpt-');
+        $identifier = \strtolower($response->id);
+
+        if (!\str_starts_with($identifier, 'gpt-') && !\str_starts_with($identifier, 'chatgpt-')) {
+            return false;
+        }
+
+        return !\str_contains($identifier, '-realtime') && !\str_contains($identifier, '-audio');
     }
 
     private function decorateModel(Responses\Models\RetrieveResponse $response): string

--- a/Resources/Private/Frontend/package-lock.json
+++ b/Resources/Private/Frontend/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@eliashaeussler/typo3-solver",
-			"version": "01.0.0,
+			"version": "1.0.0",
 			"license": "GPL-2.0-or-later",
 			"devDependencies": {
 				"@babel/core": "^7.21.4",

--- a/Tests/Unit/Command/ListModelsCommandTest.php
+++ b/Tests/Unit/Command/ListModelsCommandTest.php
@@ -63,7 +63,7 @@ final class ListModelsCommandTest extends TestingFramework\Core\Unit\UnitTestCas
     }
 
     #[Framework\Attributes\Test]
-    public function executeListsAllGPTModels(): void
+    public function executeListsAllSupportedModels(): void
     {
         $response = new Psr7\Response(headers: [
             'Content-Type' => 'application/json',
@@ -85,6 +85,13 @@ final class ListModelsCommandTest extends TestingFramework\Core\Unit\UnitTestCas
             \implode(PHP_EOL, [
                 ' * baz-1 (created at 01/01/2022)',
                 ' * foo-1 (created at 01/01/2023)',
+            ]),
+            $this->commandTester->getDisplay(),
+        );
+        self::assertStringNotContainsString(
+            \implode(PHP_EOL, [
+                ' * gpt-4o-mini-audio-preview (created at 16/12/2024)',
+                ' * gpt-4o-realtime-preview (created at 30/09/2024)',
             ]),
             $this->commandTester->getDisplay(),
         );
@@ -124,6 +131,8 @@ final class ListModelsCommandTest extends TestingFramework\Core\Unit\UnitTestCas
                 ' * foo-1 (created at 01/01/2023)',
                 ' * gpt-3.5 (created at 28/02/2023)',
                 ' * gpt-3.5-turbo-0301 (created at 01/03/2023)',
+                ' * gpt-4o-mini-audio-preview (created at 16/12/2024)',
+                ' * gpt-4o-realtime-preview (created at 30/09/2024)',
             ]),
             $this->commandTester->getDisplay(),
         );
@@ -186,6 +195,18 @@ final class ListModelsCommandTest extends TestingFramework\Core\Unit\UnitTestCas
                     'id' => 'baz-1',
                     // 01/01/2022
                     'created' => 1641038400,
+                    ...$defaults,
+                ],
+                [
+                    'id' => 'gpt-4o-realtime-preview',
+                    // 30/09/2024
+                    'created' => 1727654400,
+                    ...$defaults,
+                ],
+                [
+                    'id' => 'gpt-4o-mini-audio-preview',
+                    // 16/12/2024
+                    'created' => 1734307200,
                     ...$defaults,
                 ],
             ],


### PR DESCRIPTION
OpenAI models for Realtime and Audio API must not be included in the `solver:list-models` command output.