### PR TITLE
[TASK] Replace deprecated `max_tokens` chat completion parameter

### DIFF
--- a/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/OpenAISolutionProvider.php
@@ -120,7 +120,7 @@ final class OpenAISolutionProvider implements StreamedSolutionProvider
      * @return array{
      *     model: string,
      *     messages: list<array{role: string, content: string}>,
-     *     max_tokens: int,
+     *     max_completion_tokens: int,
      *     temperature: float,
      *     n: int,
      * }
@@ -135,7 +135,7 @@ final class OpenAISolutionProvider implements StreamedSolutionProvider
                     'content' => $problem->getPrompt(),
                 ],
             ],
-            'max_tokens' => $this->configuration->getMaxTokens(),
+            'max_completion_tokens' => $this->configuration->getMaxTokens(),
             'temperature' => $this->configuration->getTemperature(),
             'n' => $this->configuration->getNumberOfCompletions(),
         ];

--- a/Documentation/Configuration/ExtensionConfiguration.rst
+++ b/Documentation/Configuration/ExtensionConfiguration.rst
@@ -77,7 +77,7 @@ The extension currently provides the following configuration options:
     :type: integer
     :Default: `300`
 
-    `Maximum number of tokens <https://platform.openai.com/docs/api-reference/chat/create#chat/create-max_tokens>`__
+    `Maximum number of tokens <https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_completion_tokens>`__
     to use per request to OpenAI.
 
 ..  _extconf-attributes-temperature:


### PR DESCRIPTION
This PR replaces the deprecated `max_tokens` parameter by `max_completion_parameters`.