### PR TITLE
[!!!][FEATURE] Require solution providers to list available models

### DIFF
--- a/Classes/ProblemSolving/Solution/Provider/CacheSolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/CacheSolutionProvider.php
@@ -108,6 +108,11 @@ final class CacheSolutionProvider implements StreamedSolutionProvider
         return true;
     }
 
+    public function listModels(bool $includeUnsupported = false): array
+    {
+        return $this->provider->listModels($includeUnsupported);
+    }
+
     public function getProvider(): SolutionProvider
     {
         return $this->provider;

--- a/Classes/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProvider.php
+++ b/Classes/ProblemSolving/Solution/Provider/DelegatingCacheSolutionProvider.php
@@ -84,4 +84,9 @@ final class DelegatingCacheSolutionProvider implements SolutionProvider
     {
         return false;
     }
+
+    public function listModels(bool $includeUnsupported = false): array
+    {
+        return $this->delegate->listModels($includeUnsupported);
+    }
 }

--- a/Classes/ProblemSolving/Solution/Provider/Model/AiModel.php
+++ b/Classes/ProblemSolving/Solution/Provider/Model/AiModel.php
@@ -21,32 +21,25 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider;
+namespace EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider\Model;
 
-use EliasHaeussler\Typo3Solver\Exception;
-use EliasHaeussler\Typo3Solver\ProblemSolving;
+use OpenAI\Responses;
 
 /**
- * SolutionProvider.
+ * AiModel
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
-interface SolutionProvider
+final class AiModel
 {
-    public static function create(): static;
+    public function __construct(
+        public readonly string $name,
+        public readonly ?\DateTimeImmutable $createdAt = null,
+    ) {}
 
-    /**
-     * @throws Exception\UnableToSolveException
-     */
-    public function getSolution(ProblemSolving\Problem\Problem $problem): ProblemSolving\Solution\Solution;
-
-    public function canBeUsed(\Throwable $exception): bool;
-
-    public function isCacheable(): bool;
-
-    /**
-     * @return list<Model\AiModel>
-     */
-    public function listModels(bool $includeUnsupported = false): array;
+    public static function fromOpenAIRetrieveResponse(Responses\Models\RetrieveResponse $response): self
+    {
+        return new self($response->id, new \DateTimeImmutable('@' . $response->created));
+    }
 }

--- a/Documentation/DeveloperCorner/SolutionProviders.rst
+++ b/Documentation/DeveloperCorner/SolutionProviders.rst
@@ -53,6 +53,14 @@ way to solve a given problem.
 
         :returntype: bool
 
+    ..  php:method:: listModels($includeUnsupported = false)
+
+        List all AI models by the underlying AI provider. By default,
+        only supported models are returned.
+
+        :param bool $includeUnsupported: Define whether to return unsupported models as well
+        :returntype: :php:`list<EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider\Model\AiModel>`
+
 ..  php:interface:: StreamedSolutionProvider
 
     Extended interface for solution providers that are able to stream

--- a/Resources/Private/Libs/Build/composer.json
+++ b/Resources/Private/Libs/Build/composer.json
@@ -14,7 +14,7 @@
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
 		"eliashaeussler/sse": "^1.1",
 		"erusev/parsedown": "^1.7",
-		"openai-php/client": "^0.4.1 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+		"openai-php/client": "^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0",
 		"spatie/backtrace": "^1.2"
 	},
 	"provide": {

--- a/Resources/Private/Libs/Build/composer.lock
+++ b/Resources/Private/Libs/Build/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "324cde33bc22d55f7763a8b1772f5771",
+    "content-hash": "caf0075fc82ca65270944993fbd8962b",
     "packages": [
         {
             "name": "eliashaeussler/sse",

--- a/Tests/Build/console-application.php
+++ b/Tests/Build/console-application.php
@@ -36,7 +36,12 @@ $application = new Console\Application();
 
 // Add console commands
 $application->add(new Src\Command\CacheFlushCommand(new Src\Cache\SolutionsCache()));
-$application->add(new Src\Command\ListModelsCommand(OpenAI::factory()->make()));
+$application->add(
+    new Src\Command\ListModelsCommand(
+        new Src\Configuration\Configuration(),
+        Tests\Unit\Fixtures\DummySolutionProvider::create(),
+    ),
+);
 $application->add(
     new Src\Command\SolveCommand(
         new Src\Configuration\Configuration(),

--- a/Tests/CGL/phpstan-baseline.neon
+++ b/Tests/CGL/phpstan-baseline.neon
@@ -101,9 +101,3 @@ parameters:
 			identifier: offsetAccess.nonOffsetAccessible
 			count: 5
 			path: ../Unit/ProblemSolving/Solution/Provider/OpenAISolutionProviderTest.php
-
-		-
-			message: '#^Static method OpenAI\\Responses\\Chat\\CreateResponse\:\:from\(\) invoked with 1 parameter, 2 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: ../Unit/ProblemSolving/Solution/SolutionTest.php

--- a/Tests/Unit/DataProvider/SolutionDataProvider.php
+++ b/Tests/Unit/DataProvider/SolutionDataProvider.php
@@ -66,6 +66,7 @@ final class SolutionDataProvider
         return new ProblemSolving\Solution\Model\CompletionResponse(
             $index,
             new ProblemSolving\Solution\Model\Message('role', $message),
+            'stop',
         );
     }
 }

--- a/Tests/Unit/Fixtures/DummySolutionProvider.php
+++ b/Tests/Unit/Fixtures/DummySolutionProvider.php
@@ -38,6 +38,11 @@ final class DummySolutionProvider implements ProblemSolving\Solution\Provider\So
     public bool $shouldBeUsed = true;
     public bool $isCacheable = true;
 
+    /**
+     * @var list<ProblemSolving\Solution\Provider\Model\AiModel>
+     */
+    public array $models = [];
+
     public static function create(): static
     {
         return new self();
@@ -56,5 +61,10 @@ final class DummySolutionProvider implements ProblemSolving\Solution\Provider\So
     public function isCacheable(): bool
     {
         return $this->isCacheable;
+    }
+
+    public function listModels(bool $includeUnsupported = false): array
+    {
+        return $this->models;
     }
 }

--- a/Tests/Unit/Fixtures/DummyStreamedSolutionProvider.php
+++ b/Tests/Unit/Fixtures/DummyStreamedSolutionProvider.php
@@ -42,6 +42,11 @@ final class DummyStreamedSolutionProvider implements ProblemSolving\Solution\Pro
      */
     public array $solutionStream = [];
 
+    /**
+     * @var list<ProblemSolving\Solution\Provider\Model\AiModel>
+     */
+    public array $models = [];
+
     public static function create(): static
     {
         return new self();
@@ -65,5 +70,10 @@ final class DummyStreamedSolutionProvider implements ProblemSolving\Solution\Pro
     public function isCacheable(): bool
     {
         return true;
+    }
+
+    public function listModels(bool $includeUnsupported = false): array
+    {
+        return $this->models;
     }
 }

--- a/Tests/Unit/Formatter/WebStreamFormatterTest.php
+++ b/Tests/Unit/Formatter/WebStreamFormatterTest.php
@@ -64,7 +64,7 @@ final class WebStreamFormatterTest extends TestingFramework\Core\Unit\UnitTestCa
 
         self::assertSame('model', $json['data']['model'] ?? null);
         self::assertSame(3, $json['data']['numberOfResponses'] ?? null);
-        self::assertSame(3, $json['data']['numberOfPendingResponses'] ?? null);
+        self::assertSame(0, $json['data']['numberOfPendingResponses'] ?? null);
         self::assertSame('prompt', $json['data']['prompt'] ?? null);
 
         // First response

--- a/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/CacheSolutionProviderTest.php
@@ -169,6 +169,23 @@ final class CacheSolutionProviderTest extends TestingFramework\Core\Unit\UnitTes
     }
 
     #[Framework\Attributes\Test]
+    public function listModelsReturnsModelsFromDelegatedProvider(): void
+    {
+        $this->provider->models = [
+            new Src\ProblemSolving\Solution\Provider\Model\AiModel(
+                'gpt-3.5',
+                new \DateTimeImmutable('now'),
+            ),
+            new Src\ProblemSolving\Solution\Provider\Model\AiModel(
+                'gpt-3.5-turbo-0301',
+                new \DateTimeImmutable('yesterday'),
+            ),
+        ];
+
+        self::assertSame($this->provider->models, $this->subject->listModels());
+    }
+
+    #[Framework\Attributes\Test]
     public function getProviderReturnsProvider(): void
     {
         self::assertSame($this->provider, $this->subject->getProvider());

--- a/Tests/Unit/ProblemSolving/Solution/Provider/Model/AiModelTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/Provider/Model/AiModelTest.php
@@ -21,32 +21,33 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\Typo3Solver\ProblemSolving\Solution\Provider;
+namespace EliasHaeussler\Typo3Solver\Tests\Unit\ProblemSolving\Solution\Provider\Model;
 
-use EliasHaeussler\Typo3Solver\Exception;
-use EliasHaeussler\Typo3Solver\ProblemSolving;
+use EliasHaeussler\Typo3Solver as Src;
+use OpenAI\Responses;
+use PHPUnit\Framework;
+use TYPO3\TestingFramework;
 
 /**
- * SolutionProvider.
+ * AiModelTest
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
-interface SolutionProvider
+#[Framework\Attributes\CoversClass(Src\ProblemSolving\Solution\Provider\Model\AiModel::class)]
+final class AiModelTest extends TestingFramework\Core\Unit\UnitTestCase
 {
-    public static function create(): static;
+    #[Framework\Attributes\Test]
+    public function fromOpenAIRetrieveResponseReturnsAiModelFromGivenResponse(): void
+    {
+        $response = Responses\Models\RetrieveResponse::fake([
+            'id' => 'foo',
+            'created' => 1739347287,
+        ]);
 
-    /**
-     * @throws Exception\UnableToSolveException
-     */
-    public function getSolution(ProblemSolving\Problem\Problem $problem): ProblemSolving\Solution\Solution;
+        $actual = Src\ProblemSolving\Solution\Provider\Model\AiModel::fromOpenAIRetrieveResponse($response);
 
-    public function canBeUsed(\Throwable $exception): bool;
-
-    public function isCacheable(): bool;
-
-    /**
-     * @return list<Model\AiModel>
-     */
-    public function listModels(bool $includeUnsupported = false): array;
+        self::assertSame('foo', $actual->name);
+        self::assertSame(1739347287, $actual->createdAt?->getTimestamp());
+    }
 }

--- a/Tests/Unit/ProblemSolving/Solution/SolutionTest.php
+++ b/Tests/Unit/ProblemSolving/Solution/SolutionTest.php
@@ -54,52 +54,22 @@ final class SolutionTest extends TestingFramework\Core\Unit\UnitTestCase
     #[Framework\Attributes\Test]
     public function fromOpenAIResponseReturnsSolution(): void
     {
-        $attributes = [
-            'id' => 'id',
-            'object' => 'object',
-            'created' => 123,
+        $response = Responses\Chat\CreateResponse::fake([
             'model' => 'model',
             'choices' => [
                 [
-                    'index' => 0,
                     'message' => [
                         'role' => 'role',
                         'content' => 'content',
-                        'function_call' => null,
-                        'tool_calls' => null,
                     ],
-                    'finish_reason' => null,
                 ],
             ],
-            'usage' => [
-                'prompt_tokens' => 123,
-                'completion_tokens' => 123,
-                'total_tokens' => 123,
-            ],
-        ];
-
-        if (\class_exists(Responses\Meta\MetaInformation::class)) {
-            $meta = Responses\Meta\MetaInformation::from([
-                'x-request-id' => ['foo'],
-                'openai-model' => ['foo'],
-                'openai-organization' => ['foo'],
-                'openai-version' => ['foo'],
-                'openai-processing-ms' => ['foo'],
-                'x-ratelimit-limit-requests' => ['foo'],
-                'x-ratelimit-remaining-requests' => ['foo'],
-                'x-ratelimit-reset-requests' => ['foo'],
-                'x-ratelimit-limit-tokens' => ['foo'],
-                'x-ratelimit-remaining-tokens' => ['foo'],
-                'x-ratelimit-reset-tokens' => ['foo'],
-            ]);
-            $response = Responses\Chat\CreateResponse::from($attributes, $meta);
-        } else {
-            $response = Responses\Chat\CreateResponse::from($attributes);
-        }
+        ]);
 
         $completionResponse = new Src\ProblemSolving\Solution\Model\CompletionResponse(
             0,
             new Src\ProblemSolving\Solution\Model\Message('role', 'content'),
+            'stop',
         );
 
         $actual = Src\ProblemSolving\Solution\Solution::fromOpenAIResponse($response, 'prompt');

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"eliashaeussler/sse": "^1.1",
 		"erusev/parsedown": "^1.7",
 		"guzzlehttp/guzzle": "^7.5",
-		"openai-php/client": "^0.4.1 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0",
+		"openai-php/client": "^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0",
 		"psr/http-message": "^1.0 || ^2.0",
 		"psr/http-server-handler": "^1.0",
 		"psr/http-server-middleware": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c951a4c02459ab73f9bef252d9fb2d75",
+    "content-hash": "95accf46dc0cd4ee22ce9a237b7d6825",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
Solution providers must now implement the `listModels` method and provide a list of `AiModel` objects which represent their available models. This information is now consumed in the `solver:list-models` command to open it for further AI providers.