### PR TITLE
[BUGFIX] Use PHP 8.2 in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           extensions: intl, mbstring, json, zip, curl
           tools: composer:v2, eliashaeussler/typo3-vendor-bundler, typo3/tailor
 


### PR DESCRIPTION
`eliashaeussler/typo3-vendor-bundler` requires PHP >= 8.2.